### PR TITLE
fix: resume tag in progress messages, fixes sequencing

### DIFF
--- a/src/takopi/exec_bridge.py
+++ b/src/takopi/exec_bridge.py
@@ -557,10 +557,8 @@ async def _handle_message(
 
     elapsed = clock() - started_at
     status = "done" if saw_agent_message else "error"
-    final_md = (
-        progress_renderer.render_final(elapsed, answer, status=status)
-        + f"\n\nresume: `{session_id}`"
-    )
+    progress_renderer.resume_session = session_id
+    final_md = progress_renderer.render_final(elapsed, answer, status=status)
     logger.debug("[final] markdown: %s", final_md)
     final_rendered, final_entities = render_markdown(final_md)
     can_edit_final = (

--- a/tests/test_exec_render.py
+++ b/tests/test_exec_render.py
@@ -118,12 +118,14 @@ def test_progress_renderer_renders_progress_and_final() -> None:
     progress = r.render_progress(3.0)
     assert progress.startswith("working · 3s · step 3")
     assert "1\\. ✓ `bash -lc ls`" in progress
+    assert "resume: `0199a213-81c0-7800-8aa1-bbab2a035a53`" in progress
 
     final = r.render_final(3.0, "answer", status="done")
     assert final.startswith("done · 3s · step 3")
     assert "running:" not in final
     assert "ran:" not in final
-    assert final.endswith("answer")
+    assert "answer" in final
+    assert final.rstrip().endswith("resume: `0199a213-81c0-7800-8aa1-bbab2a035a53`")
 
 
 def test_progress_renderer_clamps_actions_and_ignores_unknown() -> None:


### PR DESCRIPTION
## Summary
- include resume tag in progress and final messages once the thread id is known
- render resume tag via the progress renderer

## Testing
- uv run pytest tests/test_exec_render.py