### PR TITLE
feat: relax telegram ACL to chat id

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -162,7 +162,7 @@ See `docs/adding-a-runner.md` for the full guide and a worked example.
 ```
 Telegram Update
     ↓
-poll_updates() drains backlog, long-polls, filters chat_id == from_id == cfg.chat_id
+poll_updates() drains backlog, long-polls, filters chat_id == cfg.chat_id
     ↓
 run_main_loop() spawns tasks in TaskGroup
     ↓

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ if you prefer no notifications, `--no-final-notify` edits the progress message i
 
 ## notes
 
-* private chat only: the bot only responds to the configured `chat_id`
+* the bot only responds to the configured `chat_id` (private or group)
 * run only one takopi instance per bot token: multiple instances will race telegram's `getUpdates` offsets and cause missed updates
 
 ## development

--- a/src/takopi/bridge.py
+++ b/src/takopi/bridge.py
@@ -679,7 +679,7 @@ async def poll_updates(cfg: BridgeConfig) -> AsyncIterator[dict[str, Any]]:
             msg = upd["message"]
             if "text" not in msg:
                 continue
-            if not (msg["chat"]["id"] == msg["from"]["id"] == cfg.chat_id):
+            if msg["chat"]["id"] != cfg.chat_id:
                 continue
             yield msg
 


### PR DESCRIPTION
## Summary
- allow configured chat_id in group or private chats
- update docs to match

## Testing
- make check