### PR TITLE
feat(claude): default allowed tools

### DIFF
--- a/docs/runner/claude/claude-runner.md
+++ b/docs/runner/claude/claude-runner.md
@@ -78,7 +78,7 @@ default_engine = "claude"
 
 [claude]
 model = "claude-sonnet-4-5-20250929" # optional (Claude Code supports model override in settings too)
-allowed_tools = ["Bash", "Read", "Edit"] # optional but strongly recommended for automation
+allowed_tools = ["Bash", "Read", "Edit", "Write"] # optional but strongly recommended for automation
 dangerously_skip_permissions = false # optional (high risk; prefer sandbox use only)
 use_api_billing = false             # optional (keep ANTHROPIC_API_KEY for API billing)
 ```
@@ -87,6 +87,7 @@ Notes:
 
 * `--allowedTools` exists specifically to auto-approve tools in programmatic runs. ([Claude Code][1])
 * Claude Code tools (Bash/Edit/Write/WebSearch/etc.) and whether permission is required are documented. ([Claude Code][2])
+* If `allowed_tools` is omitted, Takopi defaults to `["Bash", "Read", "Edit", "Write"]`.
 * Takopi only reads `model`, `allowed_tools`, `dangerously_skip_permissions`, and `use_api_billing` from `[claude]`.
 * By default Takopi strips `ANTHROPIC_API_KEY` from the subprocess environment so Claude uses subscription billing. Set `use_api_billing = true` to keep the key.
 

--- a/docs/runner/claude/claude-takopi-events.md
+++ b/docs/runner/claude/claude-takopi-events.md
@@ -221,10 +221,11 @@ A minimal TOML config for Claude:
 # model: opus | sonnet | haiku
 model = "sonnet"
 
-allowed_tools = ["Bash", "Read", "Write", "WebSearch"]
+allowed_tools = ["Bash", "Read", "Edit", "Write", "WebSearch"]
 dangerously_skip_permissions = false
 use_api_billing = false
 ```
 
 Takopi only maps these keys to Claude CLI flags; other options should be configured in Claude Code settings.
+If `allowed_tools` is omitted, Takopi defaults to `["Bash", "Read", "Edit", "Write"]`.
 When `use_api_billing` is false (default), Takopi strips `ANTHROPIC_API_KEY` from the Claude subprocess environment to prefer subscription billing.

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,8 @@ profile = "takopi"
 
 [claude]
 model = "sonnet"
-allowed_tools = ["Bash", "Read", "Write", "WebSearch"]
+# optional: defaults to ["Bash", "Read", "Edit", "Write"]
+allowed_tools = ["Bash", "Read", "Edit", "Write", "WebSearch"]
 dangerously_skip_permissions = false
 # uses subscription by default, override to use api billing
 use_api_billing = false

--- a/src/takopi/runners/claude.py
+++ b/src/takopi/runners/claude.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 ENGINE: EngineId = EngineId("claude")
 STDERR_TAIL_LINES = 200
+DEFAULT_ALLOWED_TOOLS = ["Bash", "Read", "Edit", "Write"]
 
 _RESUME_RE = re.compile(
     r"(?im)^\s*`?claude\s+(?:--resume|-r)\s+(?P<token>[^`\s]+)`?\s*$"
@@ -539,7 +540,10 @@ def build_runner(config: EngineConfig, _config_path: Path) -> Runner:
     claude_cmd = "claude"
 
     model = config.get("model")
-    allowed_tools = config.get("allowed_tools")
+    if "allowed_tools" in config:
+        allowed_tools = config.get("allowed_tools")
+    else:
+        allowed_tools = DEFAULT_ALLOWED_TOOLS
     dangerously_skip_permissions = config.get("dangerously_skip_permissions") is True
     use_api_billing = config.get("use_api_billing") is True
     title = str(model) if model is not None else "claude"


### PR DESCRIPTION
The default Claude `allowed_tools` set didn’t include `Edit`, so Claude Code could read files and run commands but couldn’t apply edits in headless `-p`  mode. This caused permission denials on edit attempts unless users explicitly configured `allowed_tools`.

we now default to `["Bash", "Read", "Edit", "Write"]`