### PR TITLE
fix: change confirmation prompt from (yes/no) to (y/n)

### DIFF
--- a/src/takopi/onboarding.py
+++ b/src/takopi/onboarding.py
@@ -239,7 +239,7 @@ def _confirm(message: str, *, default: bool = True) -> bool | None:
             ("class:question", f" {message} "),
         ]
         if not status["complete"]:
-            tokens.append(("class:instruction", "(yes/no) "))
+            tokens.append(("class:instruction", "(y/n) "))
         if status["answer"] is not None:
             tokens.append(("class:answer", "yes" if status["answer"] else "no"))
         return to_formatted_text(tokens)


### PR DESCRIPTION
## Summary

- Changes the confirmation prompt text from `(yes/no)` to `(y/n)` to accurately reflect that single-character input is expected
- Prevents user confusion where typing "yes" causes "es" to spill into the next prompt field

Fixes #49

## Test plan

- [x] Verified existing onboarding tests pass
- [ ] Manual test: Run `takopi` for the first time and confirm prompts now display `(y/n)`
- [ ] Manual test: Typing `y` or `n` immediately captures the response as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)