### PR TITLE
Skip git repo check for Codex runs

### DIFF
--- a/src/takopi/runners/codex.py
+++ b/src/takopi/runners/codex.py
@@ -397,7 +397,7 @@ class CodexRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         state: Any,
     ) -> list[str]:
         _ = prompt, state
-        args = [*self.extra_args, "exec", "--skip-git-repo-check", "--json"]
+        args = [*self.extra_args, "exec", "--json"]
         if resume:
             args.extend(["resume", resume.value, "-"])
         else:
@@ -572,7 +572,7 @@ def build_runner(config: EngineConfig, config_path: Path) -> Runner:
 
     extra_args_value = config.get("extra_args")
     if extra_args_value is None:
-        extra_args = ["-c", "notify=[]"]
+        extra_args = ["-c", "notify=[]", "--skip-git-repo-check"]
     elif isinstance(extra_args_value, list) and all(
         isinstance(item, str) for item in extra_args_value
     ):


### PR DESCRIPTION
Add --skip-git-repo-check to Codex exec args so Takopi can run outside git repos.