### PR TITLE
feat: add project aliases to telegram command menu

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -67,7 +67,7 @@ The Telegram adapter module containing:
 - `/cancel` routes by reply-to progress message id (accepts extra text)
 - `/{engine}` on the first line selects the engine for new threads
 - Resume parsing polls all runners via `AutoRouter.resolve_resume()` and routes to the first match
-- Bot command menu is synced on startup (`cancel` + engine commands)
+- Bot command menu is synced on startup (`cancel` + engine + project commands, capped at 100)
 
 ### `transport.py` - Transport protocol
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -362,8 +362,12 @@ Takopi SHOULD keep the bot’s slash-command menu in sync at startup by calling
 * The command list MUST include:
   * `cancel` — cancel the current run
   * one entry per configured engine
+  * one entry per configured project alias that is a valid Telegram command
 * The command list MUST NOT include commands the bot does not support.
 * Command descriptions SHOULD be terse and lowercase.
+* The command list SHOULD be capped at 100 entries per Telegram's limit; if the
+  config exceeds that limit, implementations SHOULD warn and truncate while
+  still handling all commands at runtime.
 
 ## 9. Testing requirements (MUST)
 


### PR DESCRIPTION
## Summary
- register project aliases as Telegram slash commands after runner commands
- validate aliases, warn + truncate to 100 commands while keeping /cancel
- document command menu limit and add coverage

## Testing
- just