### PR TITLE
feat: add per-project chat routing

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -325,7 +325,7 @@ See `docs/adding-a-runner.md` for the full guide and a worked example.
 ```
 Telegram Update
     ↓
-telegram/bridge.poll_updates() drains backlog, long-polls, filters chat_id == cfg.chat_id
+telegram/bridge.poll_updates() drains backlog, long-polls, filters allowed chat ids
     ↓
 telegram/bridge.run_main_loop() spawns tasks in TaskGroup
     ↓

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -31,6 +31,7 @@ path = "~/dev/z80"             # required (repo root)
 worktrees_dir = ".worktrees"   # optional, default ".worktrees"
 default_engine = "codex"       # optional, per-project override
 worktree_base = "master"       # optional, base for new branches
+chat_id = -123                 # optional, project chat id
 ```
 
 Legacy config note: top-level `bot_token` / `chat_id` are auto-migrated into
@@ -52,6 +53,7 @@ Validation rules:
 - `default_project` must match a configured project alias.
 - Project aliases cannot collide with engine ids or reserved commands (`/cancel`).
 - `default_engine` and per-project `default_engine` must be valid engine ids.
+- `projects.<alias>.chat_id` must be unique and must not match `transports.telegram.chat_id`.
 - `transport` defaults to `"telegram"` when omitted; override per-run with `--transport`.
 
 ## `takopi init`
@@ -94,6 +96,10 @@ code (backticked):
 - Without branch: `` `ctx: <project>` ``
 
 The `ctx:` line is parsed from replies and takes precedence over new directives.
+
+When a message arrives in a chat whose `chat_id` matches `projects.<alias>.chat_id`,
+Takopi defaults the project context to that alias unless a reply `ctx:` or explicit
+`/project` directive is present.
 
 ## Worktree resolution
 

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,7 @@ path = "~/dev/z80"
 worktrees_dir = ".worktrees"
 default_engine = "codex"
 worktree_base = "master"
+chat_id = -123456789        # optional, project chat id
 ```
 
 note: the default `worktrees_dir` lives inside the repo, so `.worktrees/` will
@@ -163,7 +164,7 @@ see:
 
 ## notes
 
-* the bot only responds to the configured `chat_id` (private or group)
+* the bot only responds to the primary `chat_id` plus any per-project `chat_id`
 * run only one takopi instance per bot token: multiple instances will race telegram's `getUpdates` offsets and cause missed updates
 
 ## development

--- a/src/takopi/telegram/backend.py
+++ b/src/takopi/telegram/backend.py
@@ -97,10 +97,12 @@ class TelegramBackend(TransportBackend):
             final_notify=final_notify,
         )
         voice_transcription = _build_voice_transcription_config(transport_config)
+        chat_ids = (chat_id, *runtime.project_chat_ids())
         cfg = TelegramBridgeConfig(
             bot=bot,
             runtime=runtime,
             chat_id=chat_id,
+            chat_ids=chat_ids,
             startup_msg=startup_msg,
             exec_cfg=exec_cfg,
             voice_transcription=voice_transcription,

--- a/tests/test_projects_config.py
+++ b/tests/test_projects_config.py
@@ -87,6 +87,37 @@ def test_projects_default_engine_unknown() -> None:
         )
 
 
+def test_projects_chat_id_cannot_match_transport_chat_id() -> None:
+    config = {
+        "transports": {"telegram": {"bot_token": "token", "chat_id": 123}},
+        "projects": {"z80": {"path": "/tmp/repo", "chat_id": 123}},
+    }
+    settings = TakopiSettings.model_validate(config)
+    with pytest.raises(ConfigError, match="chat_id"):
+        settings.to_projects_config(
+            config_path=Path("takopi.toml"),
+            engine_ids=["codex"],
+            reserved=("cancel",),
+        )
+
+
+def test_projects_chat_id_must_be_unique() -> None:
+    config = {
+        "transports": {"telegram": {"bot_token": "token", "chat_id": 123}},
+        "projects": {
+            "a": {"path": "/tmp/a", "chat_id": -10},
+            "b": {"path": "/tmp/b", "chat_id": -10},
+        },
+    }
+    settings = TakopiSettings.model_validate(config)
+    with pytest.raises(ConfigError, match="chat_id"):
+        settings.to_projects_config(
+            config_path=Path("takopi.toml"),
+            engine_ids=["codex"],
+            reserved=("cancel",),
+        )
+
+
 def test_projects_relative_path_resolves(tmp_path: Path) -> None:
     config_path = tmp_path / "takopi.toml"
     settings = TakopiSettings.model_validate({"projects": {"z80": {"path": "repo"}}})


### PR DESCRIPTION
# PR: Per-project chat routing for Telegram

## Summary
- Add optional per-project `chat_id` for Telegram to route messages within project group chats.
- Auto-apply project context for messages coming from a project chat (unless a reply `ctx:` or explicit `/project` directive is present).
- Keep replies in the same chat the message arrived in.

## Changes
- Config/schema updates for `projects.<alias>.chat_id` with validation for uniqueness and no overlap with the primary `transports.telegram.chat_id`.
- Runtime lookup of chat → project mapping and default context selection.
- Telegram polling now accepts the primary chat plus project chat IDs.
- Docs updated in `readme.md`, `docs/projects.md`, and `docs/developing.md`.
- Added tests for chat-id validation and chat-based context defaulting.

## Testing
- `just check`
