### PR TITLE
feat: expose thread context to CommandContext for plugin access

### DIFF
--- a/src/takopi/commands.py
+++ b/src/takopi/commands.py
@@ -70,6 +70,8 @@ class CommandContext:
     plugin_config: dict[str, Any]
     runtime: TransportRuntime
     executor: CommandExecutor
+    context: RunContext | None = None
+    thread_id: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/takopi/telegram/commands.py
+++ b/src/takopi/telegram/commands.py
@@ -1331,6 +1331,7 @@ async def _dispatch_command(
     args_text: str,
     running_tasks: RunningTasks,
     scheduler: ThreadScheduler,
+    ambient_context: RunContext | None = None,
 ) -> None:
     allowlist = cfg.runtime.allowlist
     chat_id = msg.chat_id
@@ -1374,6 +1375,8 @@ async def _dispatch_command(
         plugin_config=plugin_config,
         runtime=cfg.runtime,
         executor=executor,
+        context=ambient_context,
+        thread_id=msg.thread_id,
     )
     try:
         result = await backend.handle(ctx)

--- a/src/takopi/telegram/loop.py
+++ b/src/takopi/telegram/loop.py
@@ -559,6 +559,7 @@ async def run_main_loop(
                             args_text,
                             running_tasks,
                             scheduler,
+                            ambient_context,
                         )
                         continue
 


### PR DESCRIPTION
## Summary

Add `context` and `thread_id` fields to `CommandContext` so command backend plugins can access topic thread context when invoked from a topic thread.

## Changes

- Add `context: RunContext | None` to `CommandContext`
- Add `thread_id: int | None` to `CommandContext`
- Pass `ambient_context` through `_dispatch_command()`

## Use Case

The `takopi-ralph` plugin (and other command plugins) can now access `ctx.context.project` to know which project to operate in without requiring explicit user input when running commands in a bound topic thread.

Closes #91