### PR TITLE
feat(transport): add sender_id and raw to MessageRef for plugins

### DIFF
--- a/src/takopi/telegram/commands.py
+++ b/src/takopi/telegram/commands.py
@@ -1537,7 +1537,11 @@ async def _dispatch_command(
         stateful_mode=stateful_mode,
     )
     message_ref = MessageRef(
-        channel_id=chat_id, message_id=user_msg_id, thread_id=msg.thread_id
+        channel_id=chat_id,
+        message_id=user_msg_id,
+        thread_id=msg.thread_id,
+        sender_id=msg.sender_id,
+        raw=msg.raw,
     )
     try:
         backend = get_command(command_id, allowlist=allowlist, required=False)

--- a/src/takopi/transport.py
+++ b/src/takopi/transport.py
@@ -14,6 +14,7 @@ class MessageRef:
     message_id: MessageId
     raw: Any | None = field(default=None, compare=False, hash=False)
     thread_id: ThreadId | None = field(default=None, compare=False, hash=False)
+    sender_id: int | None = field(default=None, compare=False, hash=False)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,39 @@
+"""Tests for the transport module."""
+
+from takopi.transport import MessageRef
+
+
+def test_message_ref_sender_id_field() -> None:
+    """Test that MessageRef has sender_id field and it works correctly."""
+    # Without sender_id
+    ref1 = MessageRef(channel_id=123, message_id=456)
+    assert ref1.sender_id is None
+
+    # With sender_id
+    ref2 = MessageRef(channel_id=123, message_id=456, sender_id=789)
+    assert ref2.sender_id == 789
+
+    # sender_id should not affect equality (compare=False)
+    ref3 = MessageRef(channel_id=123, message_id=456, sender_id=999)
+    assert ref2 == ref3  # Same channel_id and message_id
+
+    # sender_id should not affect hash (hash=False)
+    assert hash(ref2) == hash(ref3)
+
+
+def test_message_ref_all_fields() -> None:
+    """Test MessageRef with all fields populated."""
+    raw_data = {"from": {"id": 789, "first_name": "Test"}}
+    ref = MessageRef(
+        channel_id=123,
+        message_id=456,
+        raw=raw_data,
+        thread_id=100,
+        sender_id=789,
+    )
+
+    assert ref.channel_id == 123
+    assert ref.message_id == 456
+    assert ref.raw == raw_data
+    assert ref.thread_id == 100
+    assert ref.sender_id == 789


### PR DESCRIPTION
## Summary

Expose `sender_id` and `raw` message data in `MessageRef` when dispatching commands to plugins.

This enables plugins to:
- **Identify the sender** via `sender_id` (universal across platforms - Telegram, Discord, Slack)
- **Access raw message data** for platform-specific features like extracting `@mention` entities from Telegram messages

## Changes

- Pass `sender_id=msg.sender_id` to MessageRef in `_dispatch_command()`
- Pass `raw=msg.raw` to MessageRef in `_dispatch_command()`
- Add tests for the new `sender_id` field

## Use Case

The `takopi-party` plugin needs these fields for access control:
- `sender_id` to identify who is running commands
- `raw` to extract user IDs from `@mentions` (via Telegram's `text_mention` entities) for `/party allow @user` and `/party revoke @user` commands

## Test Plan

- [x] Added unit tests for `sender_id` field on `MessageRef`
- [x] Verified existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)