### PR TITLE
feat(telegram): inject bot client into plugin_config

### DIFF
--- a/src/takopi/telegram/commands/dispatch.py
+++ b/src/takopi/telegram/commands/dispatch.py
@@ -78,6 +78,8 @@ async def _dispatch_command(
     except ConfigError as exc:
         await executor.send(f"error:\n{exc}", reply_to=message_ref, notify=True)
         return
+    # Inject bot client for plugins that need Telegram API access
+    plugin_config["bot"] = cfg.bot
     ctx = CommandContext(
         command=command_id,
         text=text,


### PR DESCRIPTION
## Summary

Inject the Telegram bot client into `plugin_config` so plugins can access Telegram API features.

## Changes

Added one line in `dispatch.py`:
```python
plugin_config["bot"] = cfg.bot
```

## Use Case

The `takopi-party` plugin needs the bot client to:
- Create forum topics via `bot.create_forum_topic()`
- Close/reopen topics when users leave

Currently there's no way for plugins to access the bot client. This minimal change exposes it through `ctx.plugin_config["bot"]`.

## Test Plan

- [x] Verified existing tests pass
- [x] Tested with takopi-party plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)