### PR TITLE
docs: set docs custom domain

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+takopi.banteg.xyz

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: takopi
 site_description: takopi — Telegram bridge for coding agents
-site_url: https://banteg.github.io/takopi/
+site_url: https://takopi.banteg.xyz/
 
 repo_url: https://github.com/banteg/takopi
 repo_name: banteg/takopi


### PR DESCRIPTION
- Set MkDocs site_url to https://takopi.banteg.xyz/
- Add docs/CNAME for GitHub Pages custom domain