### PR TITLE
fix(telegram): recreate stale topics

### DIFF
--- a/src/takopi/telegram/topic_state.py
+++ b/src/takopi/telegram/topic_state.py
@@ -192,6 +192,15 @@ class TopicStateStore(JsonStateStore[_TopicState]):
             thread.sessions = {}
             self._save_locked()
 
+    async def delete_thread(self, chat_id: int, thread_id: int) -> None:
+        async with self._lock:
+            self._reload_locked_if_needed()
+            key = _thread_key(chat_id, thread_id)
+            if key not in self._state.threads:
+                return
+            self._state.threads.pop(key, None)
+            self._save_locked()
+
     async def find_thread_for_context(
         self, chat_id: int, context: RunContext
     ) -> int | None:

--- a/tests/test_telegram_topic_state.py
+++ b/tests/test_telegram_topic_state.py
@@ -54,3 +54,17 @@ async def test_topic_state_store_clear_and_find(tmp_path) -> None:
     snapshot = await store.get_thread(2, 20)
     assert snapshot is not None
     assert snapshot.default_engine is None
+
+
+@pytest.mark.anyio
+async def test_topic_state_store_delete_thread(tmp_path) -> None:
+    path = tmp_path / "telegram_topics_state.json"
+    store = TopicStateStore(path)
+    context = RunContext(project="proj", branch="main")
+    await store.set_context(1, 10, context)
+    await store.set_session_resume(1, 10, ResumeToken(engine="codex", value="abc123"))
+
+    await store.delete_thread(1, 10)
+
+    assert await store.get_thread(1, 10) is None
+    assert await store.find_thread_for_context(1, context) is None


### PR DESCRIPTION
## Summary
- recreate stale Telegram topic bindings by probing edit and deleting old state
- add topic-state delete helper and tests for stale topic recreation

## Testing
- just check
