### PR TITLE
fix(telegram): handle forwarded uploads and show overrides

### DIFF
--- a/docs/reference/commands-and-directives.md
+++ b/docs/reference/commands-and-directives.md
@@ -38,6 +38,7 @@ This line is parsed from replies and takes precedence over new directives.
 | `/agent` | Show/set the default agent for the current scope. |
 | `/model` | Show/set the model override for the current scope. |
 | `/reasoning` | Show/set the reasoning override for the current scope. |
+| `/trigger` | Show/set trigger mode (mentions-only vs all). |
 | `/file put <path>` | Upload a document into the repo/worktree (requires file transfer enabled). |
 | `/file get <path>` | Fetch a file or directory back into Telegram. |
 | `/topic <project> @branch` | Create/bind a topic (topics enabled). |

--- a/src/takopi/telegram/engine_overrides.py
+++ b/src/takopi/telegram/engine_overrides.py
@@ -8,7 +8,6 @@ import msgspec
 OverrideSource = Literal["topic_override", "chat_default", "default"]
 
 REASONING_LEVELS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
-OPENCODE_REASONING_LEVELS: tuple[str, ...] = ("none", *REASONING_LEVELS)
 REASONING_SUPPORTED_ENGINES = frozenset({"codex"})
 
 
@@ -98,8 +97,7 @@ def resolve_override_value(
 
 
 def allowed_reasoning_levels(engine: str) -> tuple[str, ...]:
-    if engine == "opencode":
-        return OPENCODE_REASONING_LEVELS
+    _ = engine
     return REASONING_LEVELS
 
 

--- a/src/takopi/telegram/loop.py
+++ b/src/takopi/telegram/loop.py
@@ -1283,7 +1283,13 @@ async def run_main_loop(
                 reply = make_reply(cfg, msg)
                 text = msg.text
                 is_voice_transcribed = False
-                if _is_forwarded(msg.raw):
+                is_forward_candidate = (
+                    _is_forwarded(msg.raw)
+                    and msg.document is None
+                    and msg.voice is None
+                    and msg.media_group_id is None
+                )
+                if is_forward_candidate:
                     _attach_forward(msg)
                     continue
                 forward_key = _forward_key(msg)


### PR DESCRIPTION
## Summary
- add `/trigger` to Telegram in-chat commands table
- avoid dropping forwarded uploads by limiting forward coalescing to text-only messages
- surface model/reasoning overrides in `/agent` show and align reasoning levels

## Testing
- `uv run ruff format --check src tests`
- `uv run ruff check src tests`
- `uv run ty check src tests`
- `uv run pytest`
