### PR TITLE
docs: add takopi-discord plugin to plugins reference

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -6,6 +6,7 @@ Community and third-party plugins that extend takopi.
 |--------|------|-------------|
 | [takopi-matrix](https://github.com/Zorro909/takopi-matrix) | Transport | Matrix protocol backend with E2EE, voice transcription, and multi-room support |
 | [takopi-scripts](https://github.com/asianviking/takopi-scripts) | Command | Dynamic script runner for executing Python scripts via `/run` command |
+| [takopi-discord](https://github.com/asianviking/takopi-discord) | Transport | Discord bot backend for interacting with takopi via Discord |
 
 ## See also
 


### PR DESCRIPTION
## Summary
- Adds takopi-discord to the community plugins list in the documentation

## Test plan
- [ ] Verify the link works and points to the correct repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)