### PR TITLE
docs(takopi-slack): add takopi-slack plugin to reference

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -7,6 +7,7 @@ Community and third-party plugins that extend takopi.
 | [takopi-matrix](https://github.com/Zorro909/takopi-matrix) | Transport | Matrix protocol backend with E2EE, voice transcription, and multi-room support |
 | [takopi-scripts](https://github.com/asianviking/takopi-scripts) | Command | Dynamic script runner for executing Python scripts via `/run` command |
 | [takopi-discord](https://github.com/asianviking/takopi-discord) | Transport | Discord bot backend for interacting with takopi via Discord |
+| [takopi-slack](https://github.com/richardliang/takopi-slack-plugin) | Transport | Slack bot backend for interacting with takopi via Slack |
 
 ## See also
 


### PR DESCRIPTION
## Summary
- Adds takopi-slack to community plugins list in docs

## Test plan
- Check link works
