### PR TITLE
fix: Add Python 3.14 compatibility shim for Pydantic’s `_eval_type`

### DIFF
--- a/src/takopi/__init__.py
+++ b/src/takopi/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-import sys
 import typing
 
 __version__ = "0.21.3"
@@ -9,8 +8,6 @@ __version__ = "0.21.3"
 
 # Workaround for Pydantic calling typing._eval_type with a removed kwarg on Python 3.14.
 def _patch_typing_eval_type_for_pydantic() -> None:
-    if sys.version_info < (3, 14):
-        return
     eval_type = getattr(typing, "_eval_type", None)
     if eval_type is None:
         return


### PR DESCRIPTION
## Summary
  Fixes a Python 3.14 startup crash caused by a Pydantic incompatibility with `typing._eval_type`, and keeps lint checks green by removing an obsolete
  version gate.

  Closes #173

  ## Symptom
  On Python 3.14, `takopi --onboard` (and other CLI entrypoints) crash at import time with:

  TypeError: _eval_type() got an unexpected keyword argument 'prefer_fwd_module'

  This happens before the CLI can run any normal error handling.

  ## Cause
  Python 3.14 removed the private `prefer_fwd_module` keyword from `typing._eval_type`.
  Pydantic 2.12.5 still passes that kwarg during model construction, so importing
  `pydantic_settings` (and thus `takopi.settings`) raises immediately.

  ## Fix
  Added a minimal compatibility shim in `takopi.__init__` that:
  - Detects whether `typing._eval_type` exists.
  - Inspects its signature.
  - If `prefer_fwd_module` is not accepted, wraps `_eval_type` to drop that kwarg.

  This runs before Pydantic is imported and is a no‑op once Python/Pydantic align.

  ## Checks/Lint Follow‑up
  Ruff flagged an explicit `sys.version_info < (3, 14)` guard as obsolete because
  the project already requires Python 3.14+. I removed that guard and the unused
  `sys` import. The shim still self‑gates by signature inspection, so behavior is
  unchanged while lint passes.

  ## Tests
  - `uv run ruff format --check src tests`
  - `uv run ruff check src tests`
  - `uv run ty check src tests`
  - `uv run pytest`

  All checks pass.