### PR TITLE
feat(telegram): add allowed user gate

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -46,6 +46,7 @@ If you expect to edit config while Takopi is running, set:
 |-----|------|---------|-------|
 | `bot_token` | string | (required) | Telegram bot token from @BotFather. |
 | `chat_id` | int | (required) | Default chat id. |
+| `allowed_user_ids` | int[] | `[]` | Allowed sender user ids. Empty disables sender filtering; when set, only these users can interact (including DMs). |
 | `message_overflow` | `"trim"`\|`"split"` | `"trim"` | How to handle long final responses. |
 | `forward_coalesce_s` | float | `1.0` | Quiet window for combining a prompt with immediately-following forwarded messages; set `0` to disable. |
 | `voice_transcription` | bool | `false` | Enable voice note transcription. |
@@ -55,6 +56,8 @@ If you expect to edit config while Takopi is running, set:
 | `voice_transcription_api_key` | string\|null | `null` | Override API key for voice transcription only. |
 | `session_mode` | `"stateless"`\|`"chat"` | `"stateless"` | Auto-resume mode. Onboarding sets `"chat"` for assistant/workspace. |
 | `show_resume_line` | bool | `true` | Show resume line in message footer. Onboarding sets `false` for assistant/workspace. |
+
+When `allowed_user_ids` is set, updates without a sender id (for example, some channel posts) are ignored.
 
 ### `transports.telegram.topics`
 
@@ -71,7 +74,7 @@ If you expect to edit config while Takopi is running, set:
 | `auto_put` | bool | `true` | Auto-save uploads. |
 | `auto_put_mode` | `"upload"`\|`"prompt"` | `"upload"` | Whether uploads also start a run. |
 | `uploads_dir` | string | `"incoming"` | Relative path inside the repo/worktree. |
-| `allowed_user_ids` | int[] | `[]` | Allowed senders; empty allows private chats (group usage requires admin). |
+| `allowed_user_ids` | int[] | `[]` | Allowed senders for file transfer; empty allows private chats (group usage requires admin). |
 | `deny_globs` | string[] | (defaults) | Glob denylist (e.g. `.git/**`, `**/*.pem`). |
 
 File size limits (not configurable):

--- a/src/takopi/settings.py
+++ b/src/takopi/settings.py
@@ -94,6 +94,7 @@ class TelegramTransportSettings(BaseModel):
 
     bot_token: NonEmptyStr
     chat_id: StrictInt
+    allowed_user_ids: list[StrictInt] = Field(default_factory=list)
     message_overflow: Literal["trim", "split"] = "trim"
     voice_transcription: bool = False
     voice_max_bytes: StrictInt = 10 * 1024 * 1024

--- a/src/takopi/telegram/backend.py
+++ b/src/takopi/telegram/backend.py
@@ -142,6 +142,7 @@ class TelegramBackend(TransportBackend):
             voice_transcription_api_key=settings.voice_transcription_api_key,
             forward_coalesce_s=settings.forward_coalesce_s,
             media_group_debounce_s=settings.media_group_debounce_s,
+            allowed_user_ids=tuple(settings.allowed_user_ids),
             topics=settings.topics,
             files=settings.files,
         )

--- a/src/takopi/telegram/bridge.py
+++ b/src/takopi/telegram/bridge.py
@@ -128,6 +128,7 @@ class TelegramBridgeConfig:
     voice_transcription_api_key: str | None = None
     forward_coalesce_s: float = 1.0
     media_group_debounce_s: float = 1.0
+    allowed_user_ids: tuple[int, ...] = ()
     files: TelegramFilesSettings = field(default_factory=TelegramFilesSettings)
     chat_ids: tuple[int, ...] | None = None
     topics: TelegramTopicsSettings = field(default_factory=TelegramTopicsSettings)

--- a/tests/test_telegram_backend.py
+++ b/tests/test_telegram_backend.py
@@ -140,6 +140,7 @@ def test_telegram_backend_build_and_run_wires_config(
     transport_config = TelegramTransportSettings(
         bot_token="token",
         chat_id=321,
+        allowed_user_ids=[7, 8],
         voice_transcription=True,
         voice_max_bytes=1234,
         voice_transcription_model="whisper-1",
@@ -165,6 +166,7 @@ def test_telegram_backend_build_and_run_wires_config(
     assert cfg.voice_transcription_model == "whisper-1"
     assert cfg.voice_transcription_base_url == "http://localhost:8000/v1"
     assert cfg.voice_transcription_api_key == "local"
+    assert cfg.allowed_user_ids == (7, 8)
     assert cfg.files.enabled is True
     assert cfg.files.allowed_user_ids == [1, 2]
     assert cfg.topics.enabled is True


### PR DESCRIPTION
## Summary
- add telegram transport allowed_user_ids to gate updates and allow DMs
- include allowlist in allowed chat ids and drop disallowed senders early
- add tests and document config option

## Testing
- just check