### PR TITLE
fix(telegram): send documents to correct topic in forum chats

### DIFF
--- a/src/takopi/telegram/commands/file_transfer.py
+++ b/src/takopi/telegram/commands/file_transfer.py
@@ -578,7 +578,6 @@ async def _handle_file_get(
         chat_id=msg.chat_id,
         filename=filename,
         content=payload,
-        reply_to_message_id=msg.message_id,
         message_thread_id=msg.thread_id,
     )
     if sent is None:


### PR DESCRIPTION
## Summary
- Remove `reply_to_message_id` from `send_document()` call to fix routing issue where files were sent to DMs instead of the forum topic
- The `message_thread_id` alone correctly routes documents to the topic

## Test plan
- [ ] Send a file in a forum topic and verify it stays in that topic (not appearing in DMs)
- [ ] Send a file in a normal chat to confirm it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)