### PR TITLE
Feat/token usage display-pi

### DIFF
--- a/docs/tutorials/conversation-modes.md
+++ b/docs/tutorials/conversation-modes.md
@@ -20,7 +20,7 @@ This page explains what those settings mean and how to change them.
     explain what this repo does
 
 !!! takopi "Takopi"
-    done · codex · 8s
+    done · codex · 8s · 5k in / 800 out
     ...
 
 !!! user "You"
@@ -48,14 +48,14 @@ Tip: set a default engine for this chat with `/agent set claude`.
     explain what this repo does
 
 !!! takopi "Takopi"
-    done · codex · 8s
+    done · codex · 8s · 5k in / 800 out
     ...
     codex resume abc123
 
 To continue the same session, **reply** to a message with a resume line:
 
 !!! takopi "Takopi"
-    done · codex · 8s
+    done · codex · 8s · 5k in / 800 out
 
     !!! user "You"
         now add tests

--- a/docs/tutorials/first-run.md
+++ b/docs/tutorials/first-run.md
@@ -68,14 +68,13 @@ When the agent finishes, Takopi sends a new message and replaces the progress me
 
 
 !!! takopi "Takopi"
-    done · codex · 11s · step 5
-    
+    done · codex · 11s · step 5 · 12k in / 1.5k out
+
     Takopi is a Telegram bridge for AI coding agents (Codex, Claude Code, OpenCode, Pi). It lets you run agents from chat, manage multiple projects and git worktrees, stream progress (commands, file changes, elapsed time), and resume sessions from either chat or terminal. It also supports file transfer, group topics mapped to repo/branch contexts, and multiple engines via chat commands, with a plugin system for engines/transports/commands.
 
     codex resume 019bb89b-1b0b-7e90-96e4-c33181b49714
 
-
-That last line is the **resume line**—it's how Takopi knows which conversation to continue.
+The header shows elapsed time, steps completed, and token usage (input/output). The last line is the **resume line**—it's how Takopi knows which conversation to continue.
 
 ## 5. Continue the conversation
 
@@ -91,7 +90,7 @@ Use `/new` any time you want a fresh thread.
 **If you're in stateless mode:** **reply** to a message that has a resume line.
 
 !!! takopi "Takopi"
-    done · codex · 11s · step 5
+    done · codex · 11s · step 5 · 12k in / 1.5k out
 
     !!! user "You"
         what command line arguments does it support?

--- a/docs/tutorials/multi-engine.md
+++ b/docs/tutorials/multi-engine.md
@@ -33,7 +33,7 @@ Prefix any message with `/<engine>`:
 The engine only applies to that message. The response will have a resume line for that engine:
 
 !!! takopi "Takopi"
-    done · claude · 8s<br>
+    done · claude · 8s · 10k in / 2k out<br>
     claude --resume abc123
 
 When you reply, Takopi sees `claude --resume` and automatically uses Claude—you don't need to repeat `/claude`.

--- a/src/takopi/progress.py
+++ b/src/takopi/progress.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from collections.abc import Callable
+from typing import Any
 
 from .model import Action, ActionEvent, ResumeToken, StartedEvent, TakopiEvent
 
@@ -25,6 +26,7 @@ class ProgressState:
     resume: ResumeToken | None
     resume_line: str | None
     context_line: str | None
+    usage: dict[str, Any] | None = None
 
 
 class ProgressTracker:
@@ -34,6 +36,7 @@ class ProgressTracker:
         self.action_count = 0
         self._actions: dict[str, ActionState] = {}
         self._seq = 0
+        self._usage: dict[str, Any] | None = None
 
     def note_event(self, event: TakopiEvent) -> bool:
         match event:
@@ -77,6 +80,10 @@ class ProgressTracker:
         if resume is not None:
             self.resume = resume
 
+    def set_usage(self, usage: dict[str, Any] | None) -> None:
+        if usage is not None:
+            self._usage = usage
+
     def snapshot(
         self,
         *,
@@ -96,4 +103,5 @@ class ProgressTracker:
             resume=self.resume,
             resume_line=resume_line,
             context_line=context_line,
+            usage=self._usage,
         )

--- a/src/takopi/runner_bridge.py
+++ b/src/takopi/runner_bridge.py
@@ -586,6 +586,7 @@ async def handle_message(
         resume=resume_value,
     )
     sync_resume_token(progress_tracker, completed.resume or outcome.resume)
+    progress_tracker.set_usage(completed.usage)
     state = progress_tracker.snapshot(
         resume_formatter=runner.format_resume,
         context_line=context_line,


### PR DESCRIPTION
Show token usage (input/output breakdown) in the header of final messages.

  - `5k in / 2.5k out` - basic usage
  - `10k in (6k cached) / 1.2k out` - with cached tokens
  - `... · $0.12` - with cost (Claude)

Updates tutorial docs with new format examples.

<img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/893d8f0e-f97f-47ee-92d9-0c3a3218c2d5" />