### PR TITLE
Feature/Multi‑Repo Per [TG] Topic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,329 @@
-dist/
-.venv/
-*.egg-info/
+# Byte-compiled / optimized / DLL files
 __pycache__/
-.pytest_cache/
-.ruff_cache/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
 .coverage
-.mutmut-cache/
-mutants/
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+Pipfile.lock
+
+# poetry
+poetry.lock
+
+# pdm
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# IDEs and editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+.project
+.pydevproject
+.settings/
+*.sublime-project
+*.sublime-workspace
+*.code-workspace
+
+# VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# PyCharm
+.idea/
+*.iml
+*.iws
+*.ipr
+
+# Emacs
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Vim
+*.swp
+*.swo
+*.swn
+*.un~
+Session.vim
+.netrwhist
+tags
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Windows
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+*.stackdump
+[Dd]esktop.ini
+$RECYCLE.BIN/
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+*.lnk
+
+# Linux
+*~
+.fuse_hidden*
+.directory
+.Trash-*
+.nfs*
+
+# Project-specific
 .worktrees/
 research/
 _site/
 docs/reference/changelog.md
+
+# uv
+.uv/
+uv.lock.bak
+
+# Ruff
+.ruff_cache/
+
+# Mutmut
+.mutmut-cache/
+mutants/
+
+# Temporary files
+*.tmp
+*.temp
+*.bak
+*.backup
+*.old
+*.orig
+*.save
+
+# Logs
+*.log
+logs/
+*.log.*
+
+# Database files
+*.db
+*.sqlite
+*.sqlite3
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+.envrc
+
+# Secrets and credentials
+secrets/
+*.pem
+*.key
+*.cert
+*.crt
+*.p12
+*.pfx
+config.local.*
+secrets.yaml
+secrets.yml
+credentials.json
+
+# Local configuration
+config.local.*
+settings.local.*
+*.local.*
+
+# State files
+*.state
+*.pid
+*.lck
+# Note: uv.lock should be committed, so we don't ignore *.lock
+
+# Backup files
+*.bak
+*.backup
+*.old
+*.orig
+
+# Archive files
+*.zip
+*.tar
+*.tar.gz
+*.rar
+*.7z
+
+# Compiled files
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Package files
+*.dmg
+*.iso
+*.img
+
+# System files
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Desktop.ini

--- a/docs/explanation/routing-and-sessions.md
+++ b/docs/explanation/routing-and-sessions.md
@@ -31,6 +31,12 @@ For each message, Takopi:
 - attempts to extract a resume token by polling available runners
 - if a resume token is found, routes to the matching runner; otherwise uses the configured default engine
 
+## Chat vs topic routing
+
+- Chat routing: default project for the chat (`/ctx` outside topics).
+- Topic routing: bind a forum thread to one or more repo/branch contexts.
+- Topic bindings win inside that thread.
+
 ## Serialization (why you don’t get overlapping runs)
 
 Takopi allows parallel runs across **different threads**, but enforces serialization within a thread:

--- a/docs/how-to/topics.md
+++ b/docs/how-to/topics.md
@@ -64,13 +64,47 @@ Examples:
 
 Takopi will bind the topic and rename it to match the context.
 
+## Multi-project topics
+
+Bind multiple repo/branch contexts to one topic:
+
+```
+/topic add <project> @branch
+```
+
+Recommended flow:
+
+```
+/topic <project1> @branch1
+/topic add <project2> @branch2
+/ctx
+```
+
+Quick notes:
+- `/topic <project> @branch` replaces the binding with a single context.
+- Use `/ctx use <project>` to switch the active repo.
+
 ## Inspect or change the binding
 
 - `/ctx` shows the current binding
 - `/ctx set <project> @branch` updates it
+- `/ctx use <project>` switches the active project for repo-specific commands
 - `/ctx clear` removes it
+- `/topic rm <project>` removes a project from a multi-bound topic
+- `/topic clear` clears all project bindings
 
 Note: Outside topics (private chats or main group chats), `/ctx` binds the chat context instead of a topic.
+
+## Chat routing vs topic routing
+
+- Chat routing (`/ctx` outside topics) sets a default project for the chat.
+- Topic routing binds a specific forum thread to one or more repo/branch contexts.
+- Topic bindings win inside that thread.
+
+## Monorepo vs multi-repo topics
+
+- Monorepo: one repo, branches move together.
+- Multi-repo: separate repos must move in lockstep.
 
 ## Reset a topic session
 

--- a/src/takopi/scheduler.py
+++ b/src/takopi/scheduler.py
@@ -25,6 +25,7 @@ class ThreadJob:
     thread_id: ThreadId | None = None
     session_key: tuple[int, int | None] | None = None
     progress_ref: MessageRef | None = None
+    prompt_prelude: str | None = None
 
 
 RunJob = Callable[[ThreadJob], Awaitable[None]]
@@ -84,6 +85,7 @@ class ThreadScheduler:
         thread_id: ThreadId | None = None,
         session_key: tuple[int, int | None] | None = None,
         progress_ref: MessageRef | None = None,
+        prompt_prelude: str | None = None,
     ) -> None:
         await self.enqueue(
             ThreadJob(
@@ -95,6 +97,7 @@ class ThreadScheduler:
                 thread_id=thread_id,
                 session_key=session_key,
                 progress_ref=progress_ref,
+                prompt_prelude=prompt_prelude,
             )
         )
 

--- a/src/takopi/telegram/commands/executor.py
+++ b/src/takopi/telegram/commands/executor.py
@@ -159,6 +159,7 @@ async def _run_engine(
     show_resume_line: bool = True,
     progress_ref: MessageRef | None = None,
     run_options: EngineRunOptions | None = None,
+    prompt_prelude: str | None = None,
 ) -> None:
     reply = partial(
         send_plain,
@@ -214,10 +215,16 @@ async def _run_engine(
                 run_fields["cwd"] = str(cwd)
             bind_run_context(**run_fields)
             context_line = runtime.format_context_line(context)
+            prompt_text = text
+            if prompt_prelude:
+                if prompt_text.strip():
+                    prompt_text = f"{prompt_prelude}\n\n{prompt_text}"
+                else:
+                    prompt_text = prompt_prelude
             incoming = RunnerIncomingMessage(
                 channel_id=chat_id,
                 message_id=user_msg_id,
-                text=text,
+                text=prompt_text,
                 reply_to=reply_ref,
                 thread_id=thread_id,
             )

--- a/src/takopi/telegram/context.py
+++ b/src/takopi/telegram/context.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Sequence
 
+from ..config import ConfigError
 from ..context import RunContext
 from ..transport_runtime import TransportRuntime
+from ..utils.git import git_is_dirty
 from .topic_state import TopicThreadSnapshot
 from .topics import _topics_scope_label
 
@@ -12,7 +16,9 @@ if TYPE_CHECKING:
 
 __all__ = [
     "_format_context",
+    "_format_contexts",
     "_format_ctx_status",
+    "_build_composite_prelude",
     "_merge_topic_context",
     "_parse_project_branch_args",
     "_usage_ctx_set",
@@ -27,6 +33,23 @@ def _format_context(runtime: TransportRuntime, context: RunContext | None) -> st
     if context.branch:
         return f"{project} @{context.branch}"
     return project
+
+
+def _format_contexts(
+    runtime: TransportRuntime,
+    contexts: tuple[RunContext, ...],
+    *,
+    active_project: str | None,
+) -> str:
+    if not contexts:
+        return "none"
+    labels: list[str] = []
+    for context in contexts:
+        label = _format_context(runtime, context)
+        if active_project is not None and context.project == active_project:
+            label = f"{label} (active)"
+        labels.append(label)
+    return ", ".join(labels)
 
 
 def _usage_ctx_set(*, chat_project: str | None) -> str:
@@ -102,18 +125,28 @@ def _format_ctx_status(
     *,
     cfg: TelegramBridgeConfig,
     runtime: TransportRuntime,
-    bound: RunContext | None,
+    contexts: tuple[RunContext, ...],
+    active_project: str | None,
     resolved: RunContext | None,
     context_source: str,
     snapshot: TopicThreadSnapshot | None,
     chat_project: str | None,
 ) -> str:
+    active_ctx = None
+    if active_project is not None:
+        for ctx in contexts:
+            if ctx.project == active_project:
+                active_ctx = ctx
+                break
+    if active_ctx is None and len(contexts) == 1:
+        active_ctx = contexts[0]
     lines = [
         f"topics: enabled (scope={_topics_scope_label(cfg)})",
-        f"bound ctx: {_format_context(runtime, bound)}",
+        f"bound ctxs: {_format_contexts(runtime, contexts, active_project=active_project)}",
+        f"active ctx: {_format_context(runtime, active_ctx)}",
         f"resolved ctx: {_format_context(runtime, resolved)} (source: {context_source})",
     ]
-    if chat_project is None and bound is None:
+    if chat_project is None and not contexts:
         topic_usage = (
             _usage_topic(chat_project=chat_project).removeprefix("usage: ").strip()
         )
@@ -138,3 +171,88 @@ def _merge_topic_context(
     if bound.project is None:
         return RunContext(project=chat_project, branch=bound.branch)
     return bound
+
+
+@dataclass(frozen=True, slots=True)
+class _RepoSummary:
+    context: RunContext
+    alias: str
+    path: Path
+    git_dirty: bool | None
+
+
+def _resolve_repo_summaries(
+    runtime: TransportRuntime,
+    contexts: Sequence[RunContext],
+) -> tuple[list[_RepoSummary], str | None]:
+    summaries: list[_RepoSummary] = []
+    for ctx in contexts:
+        if ctx.project is None:
+            continue
+        try:
+            path = runtime.resolve_run_cwd(ctx)
+        except ConfigError as exc:
+            return [], f"warning: failed to resolve repo path ({exc})."
+        if path is None:
+            return [], "warning: missing project path for context."
+        summaries.append(
+            _RepoSummary(
+                context=ctx,
+                alias=runtime.project_alias_for_key(ctx.project),
+                path=path,
+                git_dirty=git_is_dirty(path),
+            )
+        )
+    return summaries, None
+
+
+def _detect_overlapping_paths(paths: Sequence[Path]) -> list[tuple[Path, Path]]:
+    resolved = [path.resolve(strict=False) for path in paths]
+    overlaps: list[tuple[Path, Path]] = []
+    for i, base in enumerate(resolved):
+        for j, other in enumerate(resolved):
+            if i == j:
+                continue
+            if other.is_relative_to(base):
+                overlaps.append((base, other))
+    return overlaps
+
+
+def _build_composite_prelude(
+    *,
+    runtime: TransportRuntime,
+    contexts: Sequence[RunContext],
+    active_project: str | None,
+) -> tuple[str | None, str | None]:
+    summaries, error = _resolve_repo_summaries(runtime, contexts)
+    if error is not None:
+        return None, error
+    if len(summaries) <= 1:
+        return None, None
+    lines: list[str] = ["[workspace]"]
+    if active_project is not None:
+        active_alias = runtime.project_alias_for_key(active_project)
+        lines.append(f"active: {active_alias}")
+    for summary in summaries:
+        branch = f" @{summary.context.branch}" if summary.context.branch else ""
+        git_state = (
+            "dirty"
+            if summary.git_dirty
+            else "clean"
+            if summary.git_dirty is False
+            else "unknown"
+        )
+        lines.append(
+            f"- {summary.alias}{branch} | {summary.path} | git: {git_state}"
+        )
+    overlaps = _detect_overlapping_paths([summary.path for summary in summaries])
+    warning = None
+    if overlaps:
+        first = overlaps[0]
+        warning = (
+            "warning: repo paths overlap "
+            f"({first[0]} contains {first[1]})."
+        )
+        lines.append(warning)
+    lines.append("[/workspace]")
+    return "\n".join(lines), warning

--- a/src/takopi/utils/git.py
+++ b/src/takopi/utils/git.py
@@ -39,6 +39,13 @@ def git_ok(args: Sequence[str], *, cwd: Path) -> bool:
     return result is not None and result.returncode == 0
 
 
+def git_is_dirty(cwd: Path) -> bool | None:
+    result = _run_git(["status", "--porcelain"], cwd=cwd)
+    if result is None or result.returncode != 0:
+        return None
+    return bool(result.stdout.strip())
+
+
 def git_is_worktree(path: Path) -> bool:
     top = git_stdout(
         ["rev-parse", "--path-format=absolute", "--show-toplevel"],

--- a/tests/test_telegram_context_helpers.py
+++ b/tests/test_telegram_context_helpers.py
@@ -134,6 +134,8 @@ def test_format_ctx_status_includes_sessions(tmp_path: Path) -> None:
     snapshot = TopicThreadSnapshot(
         chat_id=cfg.chat_id,
         thread_id=1,
+        contexts=(),
+        active_project=None,
         context=None,
         sessions={"b": "token", "a": "token2"},
         topic_title=None,
@@ -142,14 +144,16 @@ def test_format_ctx_status_includes_sessions(tmp_path: Path) -> None:
     text = tg_context._format_ctx_status(
         cfg=cfg,
         runtime=runtime,
-        bound=None,
+        contexts=(),
+        active_project=None,
         resolved=RunContext(project="alpha", branch="main"),
         context_source="directives",
         snapshot=snapshot,
         chat_project=None,
     )
     assert "topics: enabled" in text
-    assert "bound ctx: none" in text
+    assert "bound ctxs: none" in text
+    assert "active ctx: none" in text
     assert "resolved ctx: Alpha @main" in text
     assert "note: unbound topic" in text
     assert "sessions: a, b" in text


### PR DESCRIPTION
This feature adds the ability to bind multiple repositories to a single Telegram topic channel.  
A topic can now hold multiple repo/branch contexts with an active selection via `/ctx` use, while preserving the legacy single-binding `/topic <project> @branch`.

Command flow:

```text
/topic <project1> @branch1
/topic add <project2> @branch2
/ctx
```

(see: https://github.com/ToshiGGs/takopi/blob/feature/multi-repo-per-topic/docs/how-to/topics.md#multi-project-topics)

The agent receives a composite workspace summary (repo paths, branches, git clean/dirty), ambiguous routing is blocked, and behavior is unchanged for single-repo topics. Docs/tests updated; no config changes required.