### PR TITLE
feat: add Kimi Code CLI support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ codex = "takopi.runners.codex:BACKEND"
 claude = "takopi.runners.claude:BACKEND"
 opencode = "takopi.runners.opencode:BACKEND"
 pi = "takopi.runners.pi:BACKEND"
+kimi = "takopi.runners.kimi:BACKEND"
 
 [project.entry-points."takopi.transport_backends"]
 telegram = "takopi.telegram.backend:BACKEND"

--- a/src/takopi/runners/kimi.py
+++ b/src/takopi/runners/kimi.py
@@ -1,0 +1,413 @@
+"""Kimi Code CLI runner for takopi."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import msgspec
+
+from ..backends import EngineBackend, EngineConfig
+from ..events import EventFactory
+from ..logging import get_logger
+from ..model import Action, ActionKind, EngineId, ResumeToken, TakopiEvent
+from ..runner import JsonlSubprocessRunner, ResumeTokenMixin, Runner
+from ..schemas import kimi as kimi_schema
+from .run_options import get_run_options
+from .tool_actions import tool_input_path, tool_kind_and_title
+
+logger = get_logger(__name__)
+
+ENGINE: EngineId = "kimi"
+
+# Matches: `kimi --session <token>` or `kimi -S <token>`
+_RESUME_RE = re.compile(
+    r"(?im)^\s*`?kimi\s+(?:--session|-S)\s+(?P<token>[^`\s]+)`?\s*$"
+)
+
+
+@dataclass(slots=True)
+class KimiStreamState:
+    """Mutable state for processing a Kimi stream."""
+
+    factory: EventFactory = field(default_factory=lambda: EventFactory(ENGINE))
+    pending_actions: dict[str, Action] = field(default_factory=dict)
+    last_assistant_text: str | None = None
+    note_seq: int = 0
+    session_id: str | None = None
+    did_start: bool = False
+
+
+def _normalize_tool_result(content: Any) -> str:
+    """Normalize tool result content to a string."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text:
+                    parts.append(text)
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(part for part in parts if part)
+    if isinstance(content, dict):
+        text = content.get("text")
+        if isinstance(text, str):
+            return text
+    return str(content)
+
+
+def _parse_tool_arguments(arguments: str) -> dict[str, Any]:
+    """Parse the JSON arguments string from a tool call."""
+    try:
+        return json.loads(arguments)
+    except json.JSONDecodeError:
+        return {}
+
+
+def _tool_kind_and_title(
+    name: str, tool_input: dict[str, Any]
+) -> tuple[ActionKind, str]:
+    """Determine action kind and title for a tool call."""
+    return tool_kind_and_title(name, tool_input, path_keys=("file_path", "path"))
+
+
+def _tool_action(
+    tool_call: kimi_schema.ToolCall,
+) -> Action:
+    """Create an Action from a Kimi tool call."""
+    tool_id = tool_call.id
+    tool_name = tool_call.function.name
+    tool_input = _parse_tool_arguments(tool_call.function.arguments)
+
+    kind, title = _tool_kind_and_title(tool_name, tool_input)
+
+    detail: dict[str, Any] = {
+        "name": tool_name,
+        "input": tool_input,
+    }
+
+    if kind == "file_change":
+        path = tool_input_path(tool_input, path_keys=("file_path", "path"))
+        if path:
+            detail["changes"] = [{"path": path, "kind": "update"}]
+
+    return Action(id=tool_id, kind=kind, title=title, detail=detail)
+
+
+def _tool_result_event(
+    message: kimi_schema.ToolMessage,
+    *,
+    action: Action,
+    factory: EventFactory,
+) -> TakopiEvent:
+    """Create an action_completed event from a tool result message."""
+    raw_result = message.content
+    normalized = _normalize_tool_result(raw_result)
+    preview = normalized
+
+    detail = action.detail | {
+        "tool_use_id": message.tool_call_id,
+        "result_preview": preview,
+        "result_len": len(normalized),
+        "is_error": False,
+    }
+    return factory.action_completed(
+        action_id=action.id,
+        kind=action.kind,
+        title=action.title,
+        ok=True,
+        detail=detail,
+    )
+
+
+def translate_kimi_event(
+    event: kimi_schema.StreamJsonMessage,
+    *,
+    title: str,
+    state: KimiStreamState,
+    factory: EventFactory,
+) -> list[TakopiEvent]:
+    """Translate a Kimi stream event to Takopi events."""
+    match event:
+        case kimi_schema.AssistantMessage(content=content, tool_calls=tool_calls):
+            out: list[TakopiEvent] = []
+
+            # Emit started event on first assistant message if we haven't already
+            if not state.did_start:
+                state.did_start = True
+                # Generate a session ID if not provided by Kimi
+                # (Kimi doesn't emit session IDs in the same way Claude does)
+                if state.session_id is None:
+                    import uuid
+
+                    state.session_id = str(uuid.uuid4())
+                token = ResumeToken(engine=ENGINE, value=state.session_id)
+                out.append(factory.started(token, title=title))
+
+            # Store assistant text for final answer
+            if content:
+                state.last_assistant_text = content
+
+            # Process tool calls
+            if tool_calls:
+                for tool_call in tool_calls:
+                    action = _tool_action(tool_call)
+                    state.pending_actions[action.id] = action
+                    out.append(
+                        factory.action_started(
+                            action_id=action.id,
+                            kind=action.kind,
+                            title=action.title,
+                            detail=action.detail,
+                        )
+                    )
+
+            return out
+
+        case kimi_schema.ToolMessage(tool_call_id=tool_call_id):
+            out: list[TakopiEvent] = []
+            action = state.pending_actions.pop(tool_call_id, None)
+            if action is None:
+                action = Action(
+                    id=tool_call_id,
+                    kind="tool",
+                    title="tool result",
+                    detail={},
+                )
+            out.append(
+                _tool_result_event(
+                    event,
+                    action=action,
+                    factory=factory,
+                )
+            )
+            return out
+
+        case kimi_schema.UserMessage() | kimi_schema.SystemMessage():
+            # User and system messages don't generate takopi events
+            return []
+
+        case _:
+            return []
+
+
+@dataclass(slots=True)
+class KimiRunner(ResumeTokenMixin, JsonlSubprocessRunner):
+    """Runner for Kimi Code CLI."""
+
+    engine: EngineId = ENGINE
+    resume_re: re.Pattern[str] = _RESUME_RE
+
+    kimi_cmd: str = "kimi"
+    model: str | None = None
+    extra_args: list[str] = field(default_factory=list)
+    session_title: str = "kimi"
+    logger = logger
+
+    def format_resume(self, token: ResumeToken) -> str:
+        if token.engine != ENGINE:
+            raise RuntimeError(f"resume token is for engine {token.engine!r}")
+        return f"`kimi --session {token.value}`"
+
+    def _build_args(self, prompt: str, resume: ResumeToken | None) -> list[str]:
+        run_options = get_run_options()
+        args: list[str] = ["--print", "--output-format", "stream-json"]
+
+        if resume is not None:
+            args.extend(["--session", resume.value])
+
+        model = self.model
+        if run_options is not None and run_options.model:
+            model = run_options.model
+        if model is not None:
+            args.extend(["--model", str(model)])
+
+        # Add any extra args from config
+        args.extend(self.extra_args)
+
+        args.extend(["-p", prompt])
+        return args
+
+    def command(self) -> str:
+        return self.kimi_cmd
+
+    def build_args(
+        self,
+        prompt: str,
+        resume: ResumeToken | None,
+        *,
+        state: Any,
+    ) -> list[str]:
+        return self._build_args(prompt, resume)
+
+    def stdin_payload(
+        self,
+        prompt: str,
+        resume: ResumeToken | None,
+        *,
+        state: Any,
+    ) -> bytes | None:
+        # Kimi takes prompt via -p argument, not stdin
+        return None
+
+    def env(self, *, state: Any) -> dict[str, str] | None:
+        return None
+
+    def new_state(self, prompt: str, resume: ResumeToken | None) -> KimiStreamState:
+        state = KimiStreamState()
+        # If resuming, use the provided session ID
+        if resume is not None:
+            state.session_id = resume.value
+        return state
+
+    def start_run(
+        self,
+        prompt: str,
+        resume: ResumeToken | None,
+        *,
+        state: KimiStreamState,
+    ) -> None:
+        pass
+
+    def decode_jsonl(
+        self,
+        *,
+        line: bytes,
+    ) -> kimi_schema.StreamJsonMessage:
+        return kimi_schema.decode_stream_json_line(line)
+
+    def decode_error_events(
+        self,
+        *,
+        raw: str,
+        line: str,
+        error: Exception,
+        state: KimiStreamState,
+    ) -> list[TakopiEvent]:
+        if isinstance(error, msgspec.DecodeError):
+            self.get_logger().warning(
+                "jsonl.msgspec.invalid",
+                tag=self.tag(),
+                error=str(error),
+                error_type=error.__class__.__name__,
+            )
+            return []
+        return super().decode_error_events(
+            raw=raw,
+            line=line,
+            error=error,
+            state=state,
+        )
+
+    def invalid_json_events(
+        self,
+        *,
+        raw: str,
+        line: str,
+        state: KimiStreamState,
+    ) -> list[TakopiEvent]:
+        return []
+
+    def translate(
+        self,
+        data: kimi_schema.StreamJsonMessage,
+        *,
+        state: KimiStreamState,
+        resume: ResumeToken | None,
+        found_session: ResumeToken | None,
+    ) -> list[TakopiEvent]:
+        return translate_kimi_event(
+            data,
+            title=self.session_title,
+            state=state,
+            factory=state.factory,
+        )
+
+    def process_error_events(
+        self,
+        rc: int,
+        *,
+        resume: ResumeToken | None,
+        found_session: ResumeToken | None,
+        state: KimiStreamState,
+    ) -> list[TakopiEvent]:
+        message = f"kimi failed (rc={rc})."
+        resume_for_completed = found_session or resume
+        return [
+            self.note_event(message, state=state, ok=False),
+            state.factory.completed_error(
+                error=message,
+                resume=resume_for_completed,
+            ),
+        ]
+
+    def stream_end_events(
+        self,
+        *,
+        resume: ResumeToken | None,
+        found_session: ResumeToken | None,
+        state: KimiStreamState,
+    ) -> list[TakopiEvent]:
+        # Kimi doesn't emit a "result" message like Claude, so we synthesize
+        # a completed event from the last assistant text
+        if state.last_assistant_text:
+            resume_token = found_session or resume
+            if resume_token is None and state.session_id:
+                resume_token = ResumeToken(engine=ENGINE, value=state.session_id)
+            return [
+                state.factory.completed_ok(
+                    answer=state.last_assistant_text,
+                    resume=resume_token,
+                )
+            ]
+
+        if not found_session:
+            message = "kimi finished but no session_id was captured"
+            resume_for_completed = resume
+            return [
+                state.factory.completed_error(
+                    error=message,
+                    resume=resume_for_completed,
+                )
+            ]
+
+        message = "kimi finished without a result"
+        return [
+            state.factory.completed_error(
+                error=message,
+                answer=state.last_assistant_text or "",
+                resume=found_session,
+            )
+        ]
+
+
+def build_runner(config: EngineConfig, _config_path: Path) -> Runner:
+    """Build a KimiRunner from configuration."""
+    kimi_cmd = shutil.which("kimi") or "kimi"
+
+    model = config.get("model")
+    extra_args = config.get("extra_args", [])
+    title = str(model) if model is not None else "kimi"
+
+    return KimiRunner(
+        kimi_cmd=kimi_cmd,
+        model=model,
+        extra_args=extra_args,
+        session_title=title,
+    )
+
+
+BACKEND = EngineBackend(
+    id="kimi",
+    build_runner=build_runner,
+    install_cmd="curl -LsSf https://code.kimi.com/install.sh | bash",
+)

--- a/src/takopi/schemas/kimi.py
+++ b/src/takopi/schemas/kimi.py
@@ -1,0 +1,69 @@
+"""Msgspec models and decoder for Kimi Code CLI stream-json output."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+
+
+class ToolCallFunction(msgspec.Struct, forbid_unknown_fields=False):
+    """Function call details within a tool call."""
+
+    name: str
+    arguments: str  # JSON string of arguments
+
+
+class ToolCall(msgspec.Struct, forbid_unknown_fields=False):
+    """A tool call made by the assistant."""
+
+    type: str  # "function"
+    id: str
+    function: ToolCallFunction
+
+
+class UserMessage(
+    msgspec.Struct, tag="user", tag_field="role", forbid_unknown_fields=False
+):
+    """User message in the conversation."""
+
+    content: str
+
+
+class AssistantMessage(
+    msgspec.Struct, tag="assistant", tag_field="role", forbid_unknown_fields=False
+):
+    """Assistant message, optionally with tool calls."""
+
+    content: str | None = None
+    tool_calls: list[ToolCall] | None = None
+
+
+class ToolMessage(
+    msgspec.Struct, tag="tool", tag_field="role", forbid_unknown_fields=False
+):
+    """Tool execution result message."""
+
+    tool_call_id: str
+    content: str | list[dict[str, Any]] | None = None
+
+
+class SystemMessage(
+    msgspec.Struct, tag="system", tag_field="role", forbid_unknown_fields=False
+):
+    """System message (may appear in stream)."""
+
+    content: str
+
+
+type StreamJsonMessage = UserMessage | AssistantMessage | ToolMessage | SystemMessage
+
+
+STREAM_JSON_SCHEMA = msgspec.json.schema(StreamJsonMessage)
+
+_DECODER = msgspec.json.Decoder(StreamJsonMessage)
+
+
+def decode_stream_json_line(line: str | bytes) -> StreamJsonMessage:
+    """Decode a single JSONL line from Kimi stream-json output."""
+    return _DECODER.decode(line)

--- a/tests/fixtures/kimi_stream_json_session.jsonl
+++ b/tests/fixtures/kimi_stream_json_session.jsonl
@@ -1,0 +1,6 @@
+{"role":"assistant","content":"Let me check the current directory.","tool_calls":[{"type":"function","id":"tc_001","function":{"name":"Shell","arguments":"{\"command\":\"ls\"}"}}]}
+{"role":"tool","tool_call_id":"tc_001","content":"README.md\npyproject.toml\nsrc/"}
+{"role":"assistant","content":"I can see three items in the current directory:\n- README.md\n- pyproject.toml\n- src/ directory"}
+{"role":"assistant","content":"Now let me write a note.","tool_calls":[{"type":"function","id":"tc_002","function":{"name":"Write","arguments":"{\"file_path\":\"notes.md\",\"content\":\"hello world\"}"}}]}
+{"role":"tool","tool_call_id":"tc_002","content":"File written successfully"}
+{"role":"assistant","content":"Done! I've listed the files and created a notes.md file."}

--- a/tests/test_kimi_runner.py
+++ b/tests/test_kimi_runner.py
@@ -1,0 +1,283 @@
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import takopi.runners.kimi as kimi_runner
+from takopi.model import ActionEvent, CompletedEvent, ResumeToken, StartedEvent
+from takopi.runners.kimi import (
+    ENGINE,
+    KimiRunner,
+    KimiStreamState,
+    translate_kimi_event,
+)
+from takopi.schemas import kimi as kimi_schema
+
+
+def _load_fixture(name: str) -> list[kimi_schema.StreamJsonMessage]:
+    path = Path(__file__).parent / "fixtures" / name
+    events = [
+        kimi_schema.decode_stream_json_line(line)
+        for line in path.read_bytes().splitlines()
+        if line.strip()
+    ]
+    return events
+
+
+def _decode_event(payload: dict) -> kimi_schema.StreamJsonMessage:
+    data = json.dumps(payload).encode("utf-8")
+    return kimi_schema.decode_stream_json_line(data)
+
+
+def test_kimi_resume_format_and_extract() -> None:
+    runner = KimiRunner(kimi_cmd="kimi")
+    token = ResumeToken(engine=ENGINE, value="sid")
+
+    assert runner.format_resume(token) == "`kimi --session sid`"
+    assert runner.extract_resume("`kimi --session sid`") == token
+    assert runner.extract_resume("kimi -S other") == ResumeToken(
+        engine=ENGINE, value="other"
+    )
+    assert runner.extract_resume("`claude --resume sid`") is None
+
+
+def test_build_runner_uses_shutil_which(monkeypatch) -> None:
+    expected = "/usr/local/bin/kimi"
+    called: dict[str, str] = {}
+
+    def fake_which(name: str) -> str | None:
+        called["name"] = name
+        return expected
+
+    monkeypatch.setattr(kimi_runner.shutil, "which", fake_which)
+    runner = cast(KimiRunner, kimi_runner.build_runner({}, Path("takopi.toml")))
+
+    assert called["name"] == "kimi"
+    assert runner.kimi_cmd == expected
+
+
+def test_translate_fixture() -> None:
+    state = KimiStreamState()
+    events: list = []
+    for event in _load_fixture("kimi_stream_json_session.jsonl"):
+        events.extend(
+            translate_kimi_event(
+                event,
+                title="kimi",
+                state=state,
+                factory=state.factory,
+            )
+        )
+
+    # Should have a started event (from first assistant message)
+    assert isinstance(events[0], StartedEvent)
+    started = next(evt for evt in events if isinstance(evt, StartedEvent))
+    assert started.engine == ENGINE
+
+    # Should have action events for tool calls and results
+    action_events = [evt for evt in events if isinstance(evt, ActionEvent)]
+    assert len(action_events) == 4  # 2 tool starts + 2 tool completions
+
+    started_actions = {
+        (evt.action.id, evt.phase): evt
+        for evt in action_events
+        if evt.phase == "started"
+    }
+    # Shell command should be detected as "command" kind
+    assert started_actions[("tc_001", "started")].action.kind == "command"
+    # Write should be detected as "file_change" kind
+    write_action = started_actions[("tc_002", "started")].action
+    assert write_action.kind == "file_change"
+    assert write_action.detail["changes"][0]["path"] == "notes.md"
+
+    completed_actions = {
+        (evt.action.id, evt.phase): evt
+        for evt in action_events
+        if evt.phase == "completed"
+    }
+    assert completed_actions[("tc_001", "completed")].ok is True
+    assert completed_actions[("tc_002", "completed")].ok is True
+
+    # Check that state captured the last assistant text
+    assert state.last_assistant_text == "Done! I've listed the files and created a notes.md file."
+
+
+def test_translate_assistant_message_generates_started_event() -> None:
+    state = KimiStreamState()
+    event = _decode_event({"role": "assistant", "content": "Hello!"})
+
+    events = translate_kimi_event(
+        event,
+        title="kimi",
+        state=state,
+        factory=state.factory,
+    )
+
+    assert len(events) == 1
+    assert isinstance(events[0], StartedEvent)
+    assert events[0].engine == ENGINE
+    assert state.did_start is True
+
+
+def test_translate_subsequent_assistant_message_no_started() -> None:
+    state = KimiStreamState()
+    state.did_start = True
+    state.session_id = "test-session"
+    event = _decode_event({"role": "assistant", "content": "More text"})
+
+    events = translate_kimi_event(
+        event,
+        title="kimi",
+        state=state,
+        factory=state.factory,
+    )
+
+    # Should not emit another StartedEvent
+    assert len(events) == 0
+    assert state.last_assistant_text == "More text"
+
+
+def test_translate_tool_call_generates_action_started() -> None:
+    state = KimiStreamState()
+    state.did_start = True
+    state.session_id = "test-session"
+    event = _decode_event({
+        "role": "assistant",
+        "content": "Let me check.",
+        "tool_calls": [{
+            "type": "function",
+            "id": "tc_1",
+            "function": {"name": "Shell", "arguments": '{"command":"ls"}'}
+        }]
+    })
+
+    events = translate_kimi_event(
+        event,
+        title="kimi",
+        state=state,
+        factory=state.factory,
+    )
+
+    assert len(events) == 1
+    assert isinstance(events[0], ActionEvent)
+    assert events[0].phase == "started"
+    assert events[0].action.id == "tc_1"
+    assert events[0].action.kind == "command"
+
+
+def test_translate_tool_message_generates_action_completed() -> None:
+    state = KimiStreamState()
+    state.did_start = True
+    state.session_id = "test-session"
+    # Pre-populate pending action
+    from takopi.model import Action
+    state.pending_actions["tc_1"] = Action(
+        id="tc_1",
+        kind="command",
+        title="ls",
+        detail={"name": "Shell", "input": {"command": "ls"}},
+    )
+
+    event = _decode_event({
+        "role": "tool",
+        "tool_call_id": "tc_1",
+        "content": "file1.txt\nfile2.txt"
+    })
+
+    events = translate_kimi_event(
+        event,
+        title="kimi",
+        state=state,
+        factory=state.factory,
+    )
+
+    assert len(events) == 1
+    assert isinstance(events[0], ActionEvent)
+    assert events[0].phase == "completed"
+    assert events[0].action.id == "tc_1"
+    assert events[0].ok is True
+
+
+def test_translate_user_message_no_events() -> None:
+    state = KimiStreamState()
+    event = _decode_event({"role": "user", "content": "Hello"})
+
+    events = translate_kimi_event(
+        event,
+        title="kimi",
+        state=state,
+        factory=state.factory,
+    )
+
+    assert events == []
+
+
+def test_stream_end_events_with_last_text() -> None:
+    runner = KimiRunner(kimi_cmd="kimi")
+    state = KimiStreamState()
+    state.last_assistant_text = "Final answer"
+    state.session_id = "test-session"
+
+    events = runner.stream_end_events(
+        resume=None,
+        found_session=None,
+        state=state,
+    )
+
+    assert len(events) == 1
+    assert isinstance(events[0], CompletedEvent)
+    assert events[0].ok is True
+    assert events[0].answer == "Final answer"
+
+
+def test_stream_end_events_no_text() -> None:
+    runner = KimiRunner(kimi_cmd="kimi")
+    state = KimiStreamState()
+
+    events = runner.stream_end_events(
+        resume=None,
+        found_session=None,
+        state=state,
+    )
+
+    assert len(events) == 1
+    assert isinstance(events[0], CompletedEvent)
+    assert events[0].ok is False
+    assert "no session_id was captured" in events[0].error
+
+
+def test_build_args_basic() -> None:
+    runner = KimiRunner(kimi_cmd="kimi")
+    args = runner._build_args("hello", None)
+
+    assert "--print" in args
+    assert "--output-format" in args
+    assert "stream-json" in args
+    assert "-p" in args
+    assert "hello" in args
+
+
+def test_build_args_with_resume() -> None:
+    runner = KimiRunner(kimi_cmd="kimi")
+    resume = ResumeToken(engine=ENGINE, value="session-123")
+    args = runner._build_args("hello", resume)
+
+    assert "--session" in args
+    assert "session-123" in args
+
+
+def test_build_args_with_model() -> None:
+    runner = KimiRunner(kimi_cmd="kimi", model="kimi-k2")
+    args = runner._build_args("hello", None)
+
+    assert "--model" in args
+    assert "kimi-k2" in args
+
+
+def test_build_args_with_extra_args() -> None:
+    runner = KimiRunner(kimi_cmd="kimi", extra_args=["--yolo", "--thinking"])
+    args = runner._build_args("hello", None)
+
+    assert "--yolo" in args
+    assert "--thinking" in args

--- a/tests/test_kimi_schema.py
+++ b/tests/test_kimi_schema.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from takopi.schemas import kimi as kimi_schema
+
+
+def _fixture_path(name: str) -> Path:
+    return Path(__file__).parent / "fixtures" / name
+
+
+def _decode_fixture(name: str) -> list[str]:
+    path = _fixture_path(name)
+    errors: list[str] = []
+
+    for lineno, line in enumerate(path.read_bytes().splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            decoded = kimi_schema.decode_stream_json_line(line)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"line {lineno}: {exc.__class__.__name__}: {exc}")
+            continue
+
+        _ = decoded
+
+    return errors
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "kimi_stream_json_session.jsonl",
+    ],
+)
+def test_kimi_schema_parses_fixture(fixture: str) -> None:
+    errors = _decode_fixture(fixture)
+
+    assert not errors, f"{fixture} had {len(errors)} errors: " + "; ".join(errors[:5])
+
+
+def test_decode_assistant_message_with_tool_calls() -> None:
+    line = b'{"role":"assistant","content":"Let me check.","tool_calls":[{"type":"function","id":"tc_1","function":{"name":"Shell","arguments":"{\\"command\\":\\"ls\\"}"}}]}'
+    event = kimi_schema.decode_stream_json_line(line)
+
+    assert isinstance(event, kimi_schema.AssistantMessage)
+    assert event.content == "Let me check."
+    assert event.tool_calls is not None
+    assert len(event.tool_calls) == 1
+    assert event.tool_calls[0].id == "tc_1"
+    assert event.tool_calls[0].function.name == "Shell"
+    assert event.tool_calls[0].function.arguments == '{"command":"ls"}'
+
+
+def test_decode_assistant_message_without_tool_calls() -> None:
+    line = b'{"role":"assistant","content":"Hello!"}'
+    event = kimi_schema.decode_stream_json_line(line)
+
+    assert isinstance(event, kimi_schema.AssistantMessage)
+    assert event.content == "Hello!"
+    assert event.tool_calls is None
+
+
+def test_decode_tool_message() -> None:
+    line = b'{"role":"tool","tool_call_id":"tc_1","content":"file1.txt\\nfile2.txt"}'
+    event = kimi_schema.decode_stream_json_line(line)
+
+    assert isinstance(event, kimi_schema.ToolMessage)
+    assert event.tool_call_id == "tc_1"
+    assert event.content == "file1.txt\nfile2.txt"
+
+
+def test_decode_user_message() -> None:
+    line = b'{"role":"user","content":"List files please"}'
+    event = kimi_schema.decode_stream_json_line(line)
+
+    assert isinstance(event, kimi_schema.UserMessage)
+    assert event.content == "List files please"
+
+
+def test_decode_system_message() -> None:
+    line = b'{"role":"system","content":"You are a helpful assistant."}'
+    event = kimi_schema.decode_stream_json_line(line)
+
+    assert isinstance(event, kimi_schema.SystemMessage)
+    assert event.content == "You are a helpful assistant."


### PR DESCRIPTION
## Summary

- Add support for [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) as a new engine backend
- Kimi CLI is similar to Claude Code, providing AI-assisted coding in the terminal
- Follows the same architecture patterns as existing runners (Claude, Codex, OpenCode, Pi)

## Changes

**New files:**
- `src/takopi/schemas/kimi.py` - msgspec models for Kimi's `stream-json` output format
- `src/takopi/runners/kimi.py` - `KimiRunner` implementation with full event translation
- `tests/test_kimi_schema.py` - Schema parsing tests (6 tests)
- `tests/test_kimi_runner.py` - Runner and translation tests (14 tests)
- `tests/fixtures/kimi_stream_json_session.jsonl` - Test fixture

**Modified:**
- `pyproject.toml` - Added entry point for kimi backend

## Configuration

```toml
default_engine = "kimi"

[kimi]
model = "kimi-k2"  # optional
extra_args = ["--thinking"]  # optional
```

## Key Implementation Details

| Feature | Claude Code | Kimi CLI |
|---------|------------|----------|
| Resume flag | `--resume <id>` | `--session <id>` |
| Output format | Structured with `system.init`, `result` events | Role-based messages (`assistant`, `tool`, `user`) |
| Tool calls | In `message.content` array | In `tool_calls` array with JSON `arguments` |

## Test plan

- [x] All 20 new Kimi tests pass
- [x] Full test suite passes (560 tests)
- [x] Coverage maintained at 81.5%

🤖 Generated with [Claude Code](https://claude.ai/code)