### PR TITLE
feat(telegram): echo voice transcripts

### DIFF
--- a/docs/how-to/voice-notes.md
+++ b/docs/how-to/voice-notes.md
@@ -9,6 +9,7 @@ Enable transcription so voice notes become normal text runs.
     ```sh
     takopi config set transports.telegram.voice_transcription true
     takopi config set transports.telegram.voice_transcription_model "gpt-4o-mini-transcribe"
+    takopi config set transports.telegram.voice_transcription_echo true # optional
 
     # local OpenAI-compatible transcription server (optional)
     takopi config set transports.telegram.voice_transcription_base_url "http://localhost:8000/v1"
@@ -20,6 +21,7 @@ Enable transcription so voice notes become normal text runs.
     ```toml
     [transports.telegram]
     voice_transcription = true
+    voice_transcription_echo = true # optional
     voice_transcription_model = "gpt-4o-mini-transcribe" # optional
     voice_transcription_base_url = "http://localhost:8000/v1" # optional
     voice_transcription_api_key = "local" # optional
@@ -37,6 +39,7 @@ requires a specific model name, set `voice_transcription_model` (for example,
 
 When you send a voice note, Takopi transcribes it and runs the result as a normal text message.
 If transcription fails, you’ll get an error message and the run is skipped.
+If `voice_transcription_echo` is enabled, Takopi also replies to the voice note with the raw transcript.
 
 ## Related
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -50,6 +50,7 @@ If you expect to edit config while Takopi is running, set:
 | `message_overflow` | `"trim"`\|`"split"` | `"trim"` | How to handle long final responses. |
 | `forward_coalesce_s` | float | `1.0` | Quiet window for combining a prompt with immediately-following forwarded messages; set `0` to disable. |
 | `voice_transcription` | bool | `false` | Enable voice note transcription. |
+| `voice_transcription_echo` | bool | `false` | Reply to voice notes with the raw transcript. |
 | `voice_max_bytes` | int | `10485760` | Max voice note size (bytes). |
 | `voice_transcription_model` | string | `"gpt-4o-mini-transcribe"` | OpenAI transcription model name. |
 | `voice_transcription_base_url` | string\|null | `null` | Override base URL for voice transcription only. |

--- a/docs/reference/transports/telegram.md
+++ b/docs/reference/transports/telegram.md
@@ -33,6 +33,7 @@ Configuration (under `[transports.telegram]`):
     ```sh
     takopi config set transports.telegram.voice_transcription true
     takopi config set transports.telegram.voice_transcription_model "gpt-4o-mini-transcribe"
+    takopi config set transports.telegram.voice_transcription_echo true # optional
 
     # local OpenAI-compatible transcription server (optional)
     takopi config set transports.telegram.voice_transcription_base_url "http://localhost:8000/v1"
@@ -43,6 +44,7 @@ Configuration (under `[transports.telegram]`):
 
     ```toml
     voice_transcription = true
+    voice_transcription_echo = true # optional
     voice_transcription_model = "gpt-4o-mini-transcribe" # optional
     voice_transcription_base_url = "http://localhost:8000/v1" # optional
     voice_transcription_api_key = "local" # optional
@@ -51,6 +53,8 @@ Configuration (under `[transports.telegram]`):
 Set `OPENAI_API_KEY` in the environment (or `voice_transcription_api_key` in config).
 If transcription is enabled but no API key is available or the audio download fails,
 takopi replies with a short error and skips the run.
+
+If `voice_transcription_echo` is enabled, takopi also replies to the voice message with the raw transcript.
 
 To use a local OpenAI-compatible Whisper server, set `voice_transcription_base_url`
 (and `voice_transcription_api_key` if the server expects one). This keeps engine

--- a/src/takopi/settings.py
+++ b/src/takopi/settings.py
@@ -97,6 +97,7 @@ class TelegramTransportSettings(BaseModel):
     allowed_user_ids: list[StrictInt] = Field(default_factory=list)
     message_overflow: Literal["trim", "split"] = "trim"
     voice_transcription: bool = False
+    voice_transcription_echo: bool = False
     voice_max_bytes: StrictInt = 10 * 1024 * 1024
     voice_transcription_model: NonEmptyStr = "gpt-4o-mini-transcribe"
     voice_transcription_base_url: NonEmptyStr | None = None

--- a/src/takopi/telegram/backend.py
+++ b/src/takopi/telegram/backend.py
@@ -136,6 +136,7 @@ class TelegramBackend(TransportBackend):
             session_mode=settings.session_mode,
             show_resume_line=settings.show_resume_line,
             voice_transcription=settings.voice_transcription,
+            voice_transcription_echo=settings.voice_transcription_echo,
             voice_max_bytes=int(settings.voice_max_bytes),
             voice_transcription_model=settings.voice_transcription_model,
             voice_transcription_base_url=settings.voice_transcription_base_url,

--- a/src/takopi/telegram/bridge.py
+++ b/src/takopi/telegram/bridge.py
@@ -122,6 +122,7 @@ class TelegramBridgeConfig:
     session_mode: Literal["stateless", "chat"] = "stateless"
     show_resume_line: bool = True
     voice_transcription: bool = False
+    voice_transcription_echo: bool = False
     voice_max_bytes: int = 10 * 1024 * 1024
     voice_transcription_model: str = "gpt-4o-mini-transcribe"
     voice_transcription_base_url: str | None = None

--- a/tests/test_telegram_backend.py
+++ b/tests/test_telegram_backend.py
@@ -142,6 +142,7 @@ def test_telegram_backend_build_and_run_wires_config(
         chat_id=321,
         allowed_user_ids=[7, 8],
         voice_transcription=True,
+        voice_transcription_echo=True,
         voice_max_bytes=1234,
         voice_transcription_model="whisper-1",
         voice_transcription_base_url="http://localhost:8000/v1",
@@ -162,6 +163,7 @@ def test_telegram_backend_build_and_run_wires_config(
     kwargs = captured["kwargs"]
     assert cfg.chat_id == 321
     assert cfg.voice_transcription is True
+    assert cfg.voice_transcription_echo is True
     assert cfg.voice_max_bytes == 1234
     assert cfg.voice_transcription_model == "whisper-1"
     assert cfg.voice_transcription_base_url == "http://localhost:8000/v1"


### PR DESCRIPTION
## PR: Telegram voice transcription echo

Adds an optional Telegram transport setting, `transports.telegram.voice_transcription_echo` (default: `false`), to reply to voice notes with the raw transcript **before** continuing the normal run flow.

### Usage

~~~toml
[transports.telegram]
voice_transcription = true
voice_transcription_echo = true
~~~

### Behavior
- On successful transcription (and echo enabled), send a separate reply:
  - label: `voice transcript:`
  - transcript rendered as a blockquote
  - silent notify
  - respects topic `thread_id`
- Echo is only sent for non-empty transcripts
- Transcription failures unchanged (error + skip)

### Changes
- Config: add `voice_transcription_echo` to Telegram transport + bridge config; wire through backend
- Docs:
  - `docs/how-to/voice-notes.md`
  - `docs/reference/config.md`
  - `docs/reference/transports/telegram.md`
- Tests: add echo behavior coverage; extend backend wiring test

### Verification

~~~bash
uv run -m pytest -q
# 541 passed
~~~