### PR TITLE
feat: add Cursor CLI engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ takopi = "takopi.cli:main"
 [project.entry-points."takopi.engine_backends"]
 codex = "takopi.runners.codex:BACKEND"
 claude = "takopi.runners.claude:BACKEND"
+cursor = "takopi.runners.cursor:BACKEND"
 opencode = "takopi.runners.opencode:BACKEND"
 pi = "takopi.runners.pi:BACKEND"
 

--- a/src/takopi/runners/cursor.py
+++ b/src/takopi/runners/cursor.py
@@ -1,0 +1,462 @@
+"""Cursor CLI runner for Takopi.
+
+Bridges the Cursor Agent CLI (``agent -p --output-format stream-json``) to Takopi's
+normalized event model. The CLI requires a PTY to produce output, so we wrap it with
+``script -qfc`` to allocate one.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import msgspec
+
+from ..backends import EngineBackend, EngineConfig
+from ..config import ConfigError
+from ..events import EventFactory
+from ..logging import get_logger
+from ..model import ActionKind, EngineId, ResumeToken, TakopiEvent
+from ..runner import JsonlSubprocessRunner, ResumeTokenMixin, Runner
+from ..schemas import cursor as cursor_schema
+from .run_options import get_run_options
+
+logger = get_logger(__name__)
+
+ENGINE: EngineId = "cursor"
+
+__all__ = [
+    "ENGINE",
+    "CursorRunner",
+    "translate_cursor_event",
+    "BACKEND",
+]
+
+# Resume line: ``agent --resume <session_id>``
+_RESUME_RE = re.compile(r"(?im)^\s*`?agent\s+--resume\s+(?P<token>[^`\s]+)`?\s*$")
+
+
+def _extract_tool_title(tool_call: dict[str, Any] | None) -> tuple[ActionKind, str]:
+    """Return (kind, title) from a Cursor tool_call dict."""
+    if not tool_call:
+        return "tool", "tool"
+
+    # Cursor tool_call has keys like "readToolCall", "writeToolCall",
+    # "lsToolCall", "shellToolCall", etc.
+    for key, value in tool_call.items():
+        if not isinstance(value, dict):
+            continue
+        args = value.get("args", {})
+        if not isinstance(args, dict):
+            args = {}
+
+        if "shell" in key.lower() or "bash" in key.lower():
+            command = args.get("command", "shell")
+            return "command", str(command)[:80]
+        if "read" in key.lower():
+            path = args.get("path", "read")
+            return "tool", f"read {Path(path).name}" if path else "read"
+        if "write" in key.lower():
+            path = args.get("path", "write")
+            return "tool", f"write {Path(path).name}" if path else "write"
+        if "ls" in key.lower():
+            path = args.get("path", "ls")
+            return "tool", f"ls {Path(path).name}" if path else "ls"
+        if "grep" in key.lower() or "search" in key.lower():
+            pattern = args.get("pattern", "search")
+            return "tool", f"search {pattern}"[:60]
+        # Generic fallback
+        clean_key = key.replace("ToolCall", "").replace("toolCall", "")
+        return "tool", clean_key or "tool"
+
+    return "tool", "tool"
+
+
+def _build_answer_with_thinking(
+    thinking_blocks: list[str] | None,
+    answer_text: str,
+) -> str:
+    """Build final answer with thinking blocks as Discord blockquotes."""
+    if not thinking_blocks:
+        return answer_text
+
+    parts: list[str] = []
+    for i, block in enumerate(thinking_blocks):
+        # Format as Discord blockquote (> prefix on each line)
+        header = (
+            f"**💭 Thinking {i + 1}**"
+            if len(thinking_blocks) > 1
+            else "**💭 Thinking**"
+        )
+        quoted_lines = [
+            f"> {line}" if line.strip() else ">" for line in block.split("\n")
+        ]
+        parts.append(f"> {header}\n" + "\n".join(quoted_lines))
+
+    thinking_section = "\n\n".join(parts)
+    return f"{thinking_section}\n\n---\n\n{answer_text}"
+
+
+def translate_cursor_event(
+    event: cursor_schema.CursorEvent,
+    *,
+    title: str,
+    state: CursorRunState,
+    factory: EventFactory,
+) -> list[TakopiEvent]:
+    """Translate a single Cursor CLI event into Takopi event(s)."""
+    match event:
+        case cursor_schema.SystemInit(session_id=session_id, model=model):
+            token = ResumeToken(engine=ENGINE, value=session_id)
+            event_title = str(model) if model else title
+            return [factory.started(token, title=event_title)]
+
+        case cursor_schema.ToolCall(
+            subtype=subtype,
+            call_id=call_id,
+            tool_call=tool_call,
+        ):
+            if not call_id:
+                return []
+            kind, tool_title = _extract_tool_title(tool_call)
+            if subtype == "started":
+                return [
+                    factory.action_started(
+                        action_id=call_id,
+                        kind=kind,
+                        title=tool_title,
+                    )
+                ]
+            if subtype == "completed":
+                # Check for errors in tool result
+                ok = True
+                if tool_call:
+                    for value in tool_call.values():
+                        if isinstance(value, dict) and "result" in value:
+                            result = value["result"]
+                            if isinstance(result, dict) and result.get("error"):
+                                ok = False
+                return [
+                    factory.action_completed(
+                        action_id=call_id,
+                        kind=kind,
+                        title=tool_title,
+                        ok=ok,
+                    )
+                ]
+
+        case cursor_schema.AssistantResponse(message=message):
+            # Extract text from assistant message for final_answer tracking
+            if message and message.content:
+                texts = [c.text for c in message.content if c.text]
+                if texts:
+                    answer_text = "\n".join(texts)
+                    # Build final answer: thinking blocks + answer
+                    state.final_answer = _build_answer_with_thinking(
+                        state.thinking_blocks, answer_text
+                    )
+            return []
+
+        case cursor_schema.Result(
+            subtype=subtype,
+            result=result,
+            session_id=session_id,
+            duration_ms=duration_ms,
+        ):
+            raw_answer = result or state.final_answer or ""
+            # If final_answer wasn't built with thinking yet, add it now
+            if (
+                raw_answer
+                and state.thinking_blocks
+                and not raw_answer.startswith("> **")
+            ):
+                answer = _build_answer_with_thinking(state.thinking_blocks, raw_answer)
+            else:
+                answer = raw_answer
+            resume = (
+                ResumeToken(engine=ENGINE, value=session_id) if session_id else None
+            )
+            usage = {"duration_ms": duration_ms} if duration_ms else None
+            if subtype == "success" or not getattr(event, "is_error", False):
+                return [factory.completed_ok(answer=answer, resume=resume, usage=usage)]
+            else:
+                return [
+                    factory.completed_error(
+                        error=answer,
+                        answer=answer,
+                        resume=resume,
+                        usage=usage,
+                    )
+                ]
+
+        case cursor_schema.Thinking(subtype=subtype, text=text):
+            events: list[TakopiEvent] = []
+            if subtype == "delta" and text:
+                # Start tracking thinking on first delta
+                if state.thinking_chunks is None:
+                    state.thinking_chunks = []
+                    state.thinking_action_id = f"thinking-{state.note_seq}"
+                    state.note_seq += 1
+                    events.append(
+                        factory.action_started(
+                            action_id=state.thinking_action_id,
+                            kind="note",
+                            title="thinking...",
+                        )
+                    )
+                state.thinking_chunks.append(text)
+            elif subtype == "completed":
+                # Finalize thinking block
+                if state.thinking_action_id:
+                    full_text = "".join(state.thinking_chunks or []).strip()
+                    # Show a summary in the action title
+                    summary = (
+                        full_text[:80] + "..." if len(full_text) > 80 else full_text
+                    )
+                    events.append(
+                        factory.action_completed(
+                            action_id=state.thinking_action_id,
+                            kind="note",
+                            title=f"thought: {summary}",
+                            ok=True,
+                        )
+                    )
+                    # Accumulate full thinking text (don't overwrite previous blocks)
+                    if full_text:
+                        if state.thinking_blocks is None:
+                            state.thinking_blocks = []
+                        state.thinking_blocks.append(full_text)
+                    state.thinking_chunks = None
+                    state.thinking_action_id = None
+            return events
+
+        case cursor_schema.UserMessage():
+            # Echo of user message; ignore
+            return []
+
+    return []
+
+
+@dataclass(slots=True)
+class CursorRunState:
+    factory: EventFactory
+    note_seq: int = 0
+    final_answer: str | None = None
+    thinking_chunks: list[str] | None = None
+    thinking_action_id: str | None = None
+    thinking_blocks: list[str] | None = None  # accumulated thinking texts
+
+
+class CursorRunner(ResumeTokenMixin, JsonlSubprocessRunner):
+    """Takopi runner for the Cursor Agent CLI.
+
+    Wraps ``agent -p --output-format stream-json`` in ``script -qfc`` to
+    provide the PTY that the CLI requires for output.
+    """
+
+    engine: EngineId = ENGINE
+    resume_re = _RESUME_RE
+    logger = logger
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        workspace: str | None = None,
+        title: str = "Cursor",
+    ) -> None:
+        self.model = model
+        self.workspace = workspace
+        self.session_title = title
+
+    def format_resume(self, token: ResumeToken) -> str:
+        if token.engine != ENGINE:
+            raise RuntimeError(f"resume token is for engine {token.engine!r}")
+        return f"`agent --resume {token.value}`"
+
+    def command(self) -> str:
+        # We use ``script`` to wrap the agent command in a PTY.
+        return "script"
+
+    def build_args(
+        self,
+        prompt: str,
+        resume: ResumeToken | None,
+        *,
+        state: Any,
+    ) -> list[str]:
+        run_options = get_run_options()
+
+        agent_args = [
+            "agent",
+            "-p",
+            "--force",
+            "--approve-mcps",
+            "--output-format",
+            "stream-json",
+        ]
+
+        # Model selection: explicit config > run_options > default
+        model = self.model
+        if run_options and run_options.model:
+            model = run_options.model
+        if model:
+            agent_args.extend(["--model", model])
+
+        # Workspace
+        if self.workspace:
+            agent_args.extend(["--workspace", self.workspace])
+
+        # Resume
+        if resume:
+            agent_args.extend(["--resume", resume.value])
+
+        # Prompt as positional argument
+        agent_args.append(prompt)
+
+        # Wrap in ``script -qfc '...' /dev/null`` for PTY allocation.
+        # -q = quiet (no Script started/done messages)
+        # -f = flush output immediately
+        # -c = command to execute
+        agent_cmd = " ".join(shlex.quote(a) for a in agent_args)
+        return ["-qfc", agent_cmd, "/dev/null"]
+
+    def stdin_payload(
+        self,
+        prompt: str,
+        resume: ResumeToken | None,
+        *,
+        state: Any,
+    ) -> bytes | None:
+        # Cursor CLI takes the prompt as a positional arg, not stdin.
+        return None
+
+    def new_state(self, prompt: str, resume: ResumeToken | None) -> CursorRunState:
+        return CursorRunState(factory=EventFactory(ENGINE))
+
+    def start_run(
+        self,
+        prompt: str,
+        resume: ResumeToken | None,
+        *,
+        state: CursorRunState,
+    ) -> None:
+        pass
+
+    def decode_jsonl(self, *, line: bytes) -> cursor_schema.CursorEvent | None:
+        # PTY wrapper may inject ANSI escapes; silently skip non-JSON lines.
+        stripped = line.strip()
+        if not stripped or not stripped.startswith(b"{"):
+            return None
+        return cursor_schema.decode_event(stripped)
+
+    def decode_error_events(
+        self,
+        *,
+        raw: str,
+        line: str,
+        error: Exception,
+        state: CursorRunState,
+    ) -> list[TakopiEvent]:
+        if isinstance(error, msgspec.DecodeError):
+            # Cursor stream may include non-JSON lines from PTY; silently skip.
+            self.get_logger().debug(
+                "cursor.jsonl.skip",
+                tag=self.tag(),
+                error=str(error),
+                line=line[:120],
+            )
+            return []
+        return super().decode_error_events(raw=raw, line=line, error=error, state=state)
+
+    def translate(
+        self,
+        data: cursor_schema.CursorEvent | None,
+        *,
+        state: CursorRunState,
+        resume: ResumeToken | None,
+        found_session: ResumeToken | None,
+    ) -> list[TakopiEvent]:
+        if data is None:
+            return []
+        return translate_cursor_event(
+            data,
+            title=self.session_title,
+            state=state,
+            factory=state.factory,
+        )
+
+    def process_error_events(
+        self,
+        rc: int,
+        *,
+        resume: ResumeToken | None,
+        found_session: ResumeToken | None,
+        state: CursorRunState,
+    ) -> list[TakopiEvent]:
+        message = f"cursor agent failed (rc={rc})."
+        resume_for_completed = found_session or resume
+        return [
+            self.note_event(message, state=state, ok=False),
+            state.factory.completed_error(
+                error=message,
+                answer=state.final_answer or "",
+                resume=resume_for_completed,
+            ),
+        ]
+
+    def stream_end_events(
+        self,
+        *,
+        resume: ResumeToken | None,
+        found_session: ResumeToken | None,
+        state: CursorRunState,
+    ) -> list[TakopiEvent]:
+        if not found_session:
+            message = "cursor agent finished but no session_id was captured"
+            return [
+                state.factory.completed_error(
+                    error=message,
+                    answer=state.final_answer or "",
+                    resume=resume,
+                )
+            ]
+        return [
+            state.factory.completed_ok(
+                answer=state.final_answer or "",
+                resume=found_session,
+            )
+        ]
+
+    def pipes_error_message(self) -> str:
+        return "cursor agent failed to open subprocess pipes"
+
+
+def build_runner(config: EngineConfig, config_path: Path) -> Runner:
+    """Build a CursorRunner from Takopi config."""
+    model = config.get("model")
+    if model is not None and not isinstance(model, str):
+        raise ConfigError(
+            f"Invalid `cursor.model` in {config_path}; expected a string."
+        )
+
+    workspace = config.get("workspace")
+    if workspace is not None and not isinstance(workspace, str):
+        raise ConfigError(
+            f"Invalid `cursor.workspace` in {config_path}; expected a string."
+        )
+
+    title = str(model) if model else "Cursor"
+
+    return CursorRunner(model=model, workspace=workspace, title=title)
+
+
+BACKEND = EngineBackend(
+    id="cursor",
+    build_runner=build_runner,
+    cli_cmd="agent",
+    install_cmd="curl https://cursor.com/install -fsS | bash",
+)

--- a/src/takopi/schemas/cursor.py
+++ b/src/takopi/schemas/cursor.py
@@ -1,0 +1,83 @@
+"""Cursor CLI stream-json schema.
+
+Defines msgspec structs for decoding Cursor Agent CLI ``--output-format stream-json``
+events. Derived from observed output of Cursor CLI v2026.01.28.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import msgspec
+
+
+# -- Nested types --
+
+
+class TextContent(msgspec.Struct, kw_only=True):
+    type: Literal["text"]
+    text: str
+
+
+class AssistantMessage(msgspec.Struct, kw_only=True):
+    role: Literal["assistant"]
+    content: list[TextContent]
+
+
+# -- Top-level events (discriminated by "type" field) --
+
+
+class SystemInit(msgspec.Struct, tag="system", kw_only=True):
+    subtype: str  # "init"
+    session_id: str
+    model: str | None = None
+    cwd: str | None = None
+    apiKeySource: str | None = None
+    permissionMode: str | None = None
+
+
+class UserMessage(msgspec.Struct, tag="user", kw_only=True):
+    message: Any = None
+    session_id: str | None = None
+
+
+class ToolCall(msgspec.Struct, tag="tool_call", kw_only=True):
+    subtype: str  # "started" | "completed"
+    call_id: str | None = None
+    tool_call: dict[str, Any] | None = None
+    model_call_id: str | None = None
+    session_id: str | None = None
+    timestamp_ms: int | None = None
+
+
+class AssistantResponse(msgspec.Struct, tag="assistant", kw_only=True):
+    message: AssistantMessage | None = None
+    session_id: str | None = None
+
+
+class Thinking(msgspec.Struct, tag="thinking", kw_only=True):
+    subtype: str  # "delta" | "completed"
+    text: str | None = None
+    session_id: str | None = None
+    timestamp_ms: int | None = None
+
+
+class Result(msgspec.Struct, tag="result", kw_only=True):
+    subtype: str  # "success" | "error"
+    result: str | None = None
+    duration_ms: int | None = None
+    duration_api_ms: int | None = None
+    is_error: bool | None = None
+    session_id: str | None = None
+    request_id: str | None = None
+
+
+type CursorEvent = (
+    SystemInit | UserMessage | ToolCall | AssistantResponse | Thinking | Result
+)
+
+_DECODER = msgspec.json.Decoder(CursorEvent)
+
+
+def decode_event(data: bytes | str) -> CursorEvent:
+    return _DECODER.decode(data)

--- a/tests/fixtures/cursor_stream_error.jsonl
+++ b/tests/fixtures/cursor_stream_error.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","session_id":"b2c3d4e5-f6a7-8901-bcde-f12345678901","model":"Claude 4.6 Opus (Thinking)","cwd":"/home/user/project","apiKeySource":"ANTHROPIC_API_KEY","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"Do something impossible."}]},"session_id":"b2c3d4e5-f6a7-8901-bcde-f12345678901"}
+{"type":"result","subtype":"error","result":"Request failed due to upstream error.","session_id":"b2c3d4e5-f6a7-8901-bcde-f12345678901","duration_ms":500,"duration_api_ms":300,"is_error":true}

--- a/tests/fixtures/cursor_stream_success.jsonl
+++ b/tests/fixtures/cursor_stream_success.jsonl
@@ -1,0 +1,9 @@
+{"type":"system","subtype":"init","session_id":"a1b2c3d4-e5f6-7890-abcd-ef1234567890","model":"Claude 4.6 Opus (Thinking)","cwd":"/home/user/project","apiKeySource":"ANTHROPIC_API_KEY","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"List the files in the current directory."}]},"session_id":"a1b2c3d4-e5f6-7890-abcd-ef1234567890"}
+{"type":"thinking","subtype":"delta","text":"Let me list the directory contents.","session_id":"a1b2c3d4-e5f6-7890-abcd-ef1234567890","timestamp_ms":1700000000000}
+{"type":"thinking","subtype":"delta","text":" I will use the ls tool.","session_id":"a1b2c3d4-e5f6-7890-abcd-ef1234567890","timestamp_ms":1700000000100}
+{"type":"thinking","subtype":"completed","session_id":"a1b2c3d4-e5f6-7890-abcd-ef1234567890","timestamp_ms":1700000000200}
+{"type":"tool_call","subtype":"started","call_id":"call_read_001","tool_call":{"readToolCall":{"args":{"path":"/home/user/project/README.md"}}},"session_id":"a1b2c3d4-e5f6-7890-abcd-ef1234567890","timestamp_ms":1700000000300}
+{"type":"tool_call","subtype":"completed","call_id":"call_read_001","tool_call":{"readToolCall":{"result":{"content":"Project README"}}},"session_id":"a1b2c3d4-e5f6-7890-abcd-ef1234567890","timestamp_ms":1700000000400}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I found README.md. Here is the content: Project README"}]},"session_id":"a1b2c3d4-e5f6-7890-abcd-ef1234567890"}
+{"type":"result","subtype":"success","result":"I found README.md. Here is the content: Project README","session_id":"a1b2c3d4-e5f6-7890-abcd-ef1234567890","duration_ms":2500,"duration_api_ms":2200,"is_error":false}

--- a/tests/test_cursor_runner.py
+++ b/tests/test_cursor_runner.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import anyio
+import pytest
+
+from takopi.events import EventFactory
+from takopi.model import ActionEvent, CompletedEvent, ResumeToken, StartedEvent
+from takopi.runners.cursor import (
+    ENGINE,
+    CursorRunner,
+    CursorRunState,
+    translate_cursor_event,
+)
+from takopi.schemas import cursor as cursor_schema
+
+
+def _load_fixture(name: str) -> list[cursor_schema.CursorEvent]:
+    path = Path(__file__).parent / "fixtures" / name
+    events: list[cursor_schema.CursorEvent] = []
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        try:
+            decoded = cursor_schema.decode_event(line)
+        except Exception as exc:  # noqa: BLE001
+            raise AssertionError(f"{name} contained unparseable line: {line}") from exc
+        events.append(decoded)
+    return events
+
+
+def test_cursor_resume_format_and_extract() -> None:
+    runner = CursorRunner(model=None, workspace=None)
+    token = ResumeToken(engine=ENGINE, value="abc-123-def")
+
+    assert runner.format_resume(token) == "`agent --resume abc-123-def`"
+    assert runner.extract_resume("`agent --resume abc-123-def`") == token
+    assert runner.extract_resume("agent --resume abc-123-def") == token
+    assert runner.extract_resume("`claude --resume xyz`") is None
+
+
+def test_build_args_new_session() -> None:
+    runner = CursorRunner(model=None, workspace="/home/user/project")
+    state = CursorRunState(factory=runner.new_state("hello", None).factory)
+
+    with patch("takopi.runners.cursor.get_run_options", return_value=None):
+        args = runner.build_args("hello", None, state=state)
+
+    # build_args returns args for script: -qfc, quoted agent cmd, /dev/null
+    assert args[0] == "-qfc"
+    assert args[-1] == "/dev/null"
+    arg_str = args[1]
+    assert "agent" in arg_str
+    assert "-p" in arg_str
+    assert "--workspace" in arg_str
+    assert "/home/user/project" in arg_str
+    assert "hello" in arg_str
+
+
+def test_build_args_with_resume() -> None:
+    runner = CursorRunner(model=None, workspace=None)
+    resume = ResumeToken(engine=ENGINE, value="session-abc-123")
+    state = CursorRunState(factory=runner.new_state("hi", resume).factory)
+
+    with patch("takopi.runners.cursor.get_run_options", return_value=None):
+        args = runner.build_args("hi", resume, state=state)
+
+    arg_str = " ".join(args)
+    assert "--resume" in arg_str
+    assert "session-abc-123" in arg_str
+
+
+def test_build_args_with_model() -> None:
+    runner = CursorRunner(model="Claude-4-Opus", workspace=None)
+    state = CursorRunState(factory=runner.new_state("hi", None).factory)
+
+    with patch("takopi.runners.cursor.get_run_options", return_value=None):
+        args = runner.build_args("hi", None, state=state)
+
+    arg_str = " ".join(args)
+    assert "--model" in arg_str
+    assert "Claude-4-Opus" in arg_str
+
+
+def test_translate_success_fixture() -> None:
+    state = CursorRunState(factory=EventFactory(ENGINE))
+    events: list = []
+    for event in _load_fixture("cursor_stream_success.jsonl"):
+        events.extend(
+            translate_cursor_event(
+                event, title="Cursor", state=state, factory=state.factory
+            )
+        )
+
+    started = next(evt for evt in events if isinstance(evt, StartedEvent))
+    assert started.resume.value == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+    action_events = [evt for evt in events if isinstance(evt, ActionEvent)]
+    assert (
+        len(action_events) >= 2
+    )  # thinking started+completed, tool read started+completed
+
+    completed = next(evt for evt in events if isinstance(evt, CompletedEvent))
+    assert completed.ok is True
+    assert "I found README.md" in (completed.answer or "")
+    assert completed.resume == started.resume
+
+
+def test_translate_error_fixture() -> None:
+    state = CursorRunState(factory=EventFactory(ENGINE))
+    events: list = []
+    for event in _load_fixture("cursor_stream_error.jsonl"):
+        events.extend(
+            translate_cursor_event(
+                event, title="Cursor", state=state, factory=state.factory
+            )
+        )
+
+    completed = next(evt for evt in events if isinstance(evt, CompletedEvent))
+    assert completed.ok is False
+    assert "Request failed" in (completed.error or completed.answer or "")
+
+
+def test_translate_thinking_blocks() -> None:
+    state = CursorRunState(factory=EventFactory(ENGINE))
+    events: list = []
+
+    # Simulate thinking delta + completed, then assistant, then result
+    thinking_delta = cursor_schema.Thinking(
+        subtype="delta",
+        text="Analyzing the request...",
+        session_id="test-session",
+        timestamp_ms=1000,
+    )
+    thinking_complete = cursor_schema.Thinking(
+        subtype="completed",
+        text=None,
+        session_id="test-session",
+        timestamp_ms=1100,
+    )
+    assistant = cursor_schema.AssistantResponse(
+        message=cursor_schema.AssistantMessage(
+            role="assistant",
+            content=[
+                cursor_schema.TextContent(type="text", text="Here is the answer.")
+            ],
+        ),
+        session_id="test-session",
+    )
+    result = cursor_schema.Result(
+        subtype="success",
+        result="Here is the answer.",
+        session_id="test-session",
+        duration_ms=500,
+        duration_api_ms=400,
+        is_error=False,
+    )
+
+    for evt in [thinking_delta, thinking_complete, assistant, result]:
+        events.extend(
+            translate_cursor_event(
+                evt, title="Cursor", state=state, factory=state.factory
+            )
+        )
+
+    completed = next(evt for evt in events if isinstance(evt, CompletedEvent))
+    assert completed.ok is True
+    assert "> **" in (completed.answer or "")
+    assert "Thinking" in (completed.answer or "")
+    assert "Analyzing the request" in (completed.answer or "")
+    assert "Here is the answer" in (completed.answer or "")
+
+
+@pytest.mark.anyio
+async def test_run_serializes_same_session() -> None:
+    runner = CursorRunner(model=None, workspace=None)
+    gate = anyio.Event()
+    in_flight = 0
+    max_in_flight = 0
+
+    async def run_stub(*_args, **_kwargs):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        try:
+            await gate.wait()
+            yield CompletedEvent(
+                engine=ENGINE,
+                resume=ResumeToken(engine=ENGINE, value="session-123"),
+                ok=True,
+                answer="ok",
+            )
+        finally:
+            in_flight -= 1
+
+    runner.run_impl = run_stub  # type: ignore[assignment]
+
+    async def drain(prompt: str, resume: ResumeToken | None) -> None:
+        async for _event in runner.run(prompt, resume):
+            pass
+
+    token = ResumeToken(engine=ENGINE, value="session-123")
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(drain, "a", token)
+        tg.start_soon(drain, "b", token)
+        await anyio.sleep(0)
+        gate.set()
+    assert max_in_flight == 1

--- a/tests/test_cursor_schema.py
+++ b/tests/test_cursor_schema.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from takopi.schemas import cursor as cursor_schema
+
+
+def _fixture_path(name: str) -> Path:
+    return Path(__file__).parent / "fixtures" / name
+
+
+def _decode_fixture(name: str) -> list[str]:
+    path = _fixture_path(name)
+    errors: list[str] = []
+
+    for lineno, line in enumerate(path.read_bytes().splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            decoded = cursor_schema.decode_event(line)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"line {lineno}: {exc.__class__.__name__}: {exc}")
+            continue
+
+        _ = decoded
+
+    return errors
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "cursor_stream_success.jsonl",
+        "cursor_stream_error.jsonl",
+    ],
+)
+def test_cursor_schema_parses_fixture(fixture: str) -> None:
+    errors = _decode_fixture(fixture)
+
+    assert not errors, f"{fixture} had {len(errors)} errors: " + "; ".join(errors[:5])


### PR DESCRIPTION
## Summary

Adds a built-in engine backend for the **Cursor Agent CLI** (`agent`), bringing Cursor alongside the existing codex, claude, opencode, and pi engines.

## Why

Cursor is one of the most popular AI-native IDEs, and its CLI (`agent -p`) enables headless agent sessions from the terminal. However, integrating it with Takopi has a few non-trivial challenges:

1. **PTY requirement**: Unlike other engines that write to stdout normally, Cursor CLI produces no output unless connected to a PTY. This runner wraps the command with `script -qfc` to allocate one — a pattern not needed by any other engine.
2. **Unique stream-json format**: Cursor's event schema uses a different structure from Claude/Codex (e.g., dynamic `tool_call` keys like `readToolCall`, `shellToolCall` instead of a unified tool use type). This requires a dedicated schema and translation layer.
3. **Thinking support**: Cursor emits `thinking` events as streaming deltas that need accumulation, then renders them as Markdown blockquotes in the final answer — useful for understanding the agent's reasoning.
4. **Growing demand**: With Cursor's large user base and the recent release of its CLI, users want to manage Cursor agent sessions remotely — exactly what Takopi enables.

## What

- `src/takopi/schemas/cursor.py` — msgspec structs for Cursor's `stream-json` events (SystemInit, UserMessage, ToolCall, AssistantResponse, Thinking, Result)
- `src/takopi/runners/cursor.py` — `CursorRunner` that translates Cursor events into Takopi's event model, with PTY allocation, thinking accumulation, friendly tool progress titles, and resume support via `agent --resume`
- `pyproject.toml` — registered as `cursor` engine backend
- `tests/test_cursor_schema.py` — fixture-based decode tests
- `tests/test_cursor_runner.py` — resume, build_args, translation (success/error/thinking), and session serialization tests
- `tests/fixtures/cursor_stream_success.jsonl` / `cursor_stream_error.jsonl` — test fixtures

## Testing

```
uv run pytest tests/test_cursor_schema.py tests/test_cursor_runner.py -v
uv run ruff check src/takopi/schemas/cursor.py src/takopi/runners/cursor.py
uv run ruff format --check src/takopi/schemas/cursor.py src/takopi/runners/cursor.py
uv run ty check src/takopi/schemas/cursor.py src/takopi/runners/cursor.py
```

All 10 tests pass. Ruff, format, and ty checks pass.

Manual testing done via `takopi cursor --transport discord` with Cursor CLI v2026.01.28.

## Config example

```toml
default_engine = "cursor"

[cursor]
model = "opus-4.6-thinking"
workspace = "/path/to/project"
```