### PR TITLE
fix(telegram): preserve numbering with malformed nested lists

### DIFF
--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,3 +1,5 @@
+import re
+
 from takopi.telegram.render import render_markdown, split_markdown_body
 
 
@@ -18,6 +20,34 @@ def test_render_markdown_code_fence_language_is_string() -> None:
     assert entities is not None
     assert any(e.get("type") == "pre" and e.get("language") == "py" for e in entities)
     assert any(e.get("type") == "code" for e in entities)
+
+
+def test_render_markdown_keeps_ordered_numbering_with_unindented_sub_bullets() -> None:
+    md = (
+        "1. Tune maker\n"
+        "- Sweep\n"
+        "- Keep data\n"
+        "1. Increase\n"
+        "- Raise target\n"
+        "- Keep\n"
+        "1. Train\n"
+        "- Start\n"
+        "1. Add\n"
+        "- Keep exposure\n"
+        "1. Run\n"
+        "- Target pnl\n"
+    )
+
+    text, _ = render_markdown(md)
+    numbered = [line for line in text.splitlines() if re.match(r"^\d+\.\s", line)]
+
+    assert numbered == [
+        "1. Tune maker",
+        "2. Increase",
+        "3. Train",
+        "4. Add",
+        "5. Run",
+    ]
 
 
 def test_split_markdown_body_closes_and_reopens_fence() -> None:


### PR DESCRIPTION
## Summary
- normalize markdown before Telegram conversion so unindented `-` bullets after ordered items are treated as nested bullets
- prevent CommonMark from splitting each numbered step into separate one-item lists that all render as `1.`
- add a regression test covering the reported `1. ... - ... 1. ...` pattern

## Verification
- uv run pytest --no-cov tests/test_rendering.py tests/test_exec_render.py -q
- uv run pytest --no-cov tests/test_exec_bridge.py -q
- uv run ruff check src/takopi/telegram/render.py tests/test_rendering.py
