### PR TITLE
fix: use cmd /c on Windows for subprocess resolution

### DIFF
--- a/src/takopi/utils/subprocess.py
+++ b/src/takopi/utils/subprocess.py
@@ -73,6 +73,8 @@ async def manage_subprocess(
     """Ensure subprocesses receive SIGTERM, then SIGKILL after a 2s timeout."""
     if os.name == "posix":
         kwargs.setdefault("start_new_session", True)
+    elif os.name == "nt":
+        cmd = ["cmd", "/c", *cmd]
     proc = await anyio.open_process(cmd, **kwargs)
     try:
         yield proc


### PR DESCRIPTION
This PR updates the manage_subprocess context manager to ensure subprocesses on Windows can resolve commands installed via npm (or other PATH-dependent executables).

When running Python in isolated Python environments on Windows (e.g., inside uv), globally installed npm executables like codex are not visible to subprocesses, because the isolated environment does not inherit the system/user PATH. Attempting to run these commands currently causes:
```
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

Prepending `cmd /c` allows the Windows shell to correctly resolve these executables, without needing to modify the Python environment or PATH, providing a clean, minimal, cross-platform solution.