### PR TITLE
chore(dev): add lockfile-aware dependency bootstrap script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
+    "coverage>=7.13.1",
     "mutmut>=3.4.0",
     "pytest>=9.0.2",
     "pytest-anyio>=0.0.0",

--- a/readme.md
+++ b/readme.md
@@ -69,5 +69,7 @@ see [`docs/how-to/write-a-plugin.md`](docs/how-to/write-a-plugin.md) and [`docs/
 
 ## development
 
+install dependencies with `bash scripts/install-deps.sh` (lockfile-driven: `uv`, `bun`, `pnpm`, `npm`, `yarn`).
+
 see [`docs/reference/specification.md`](docs/reference/specification.md) and [`docs/developing.md`](docs/developing.md).
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -f uv.lock ]]; then
+  echo "[deps] uv lockfile detected -> uv sync --group dev"
+  exec uv sync --group dev "$@"
+elif [[ -f bun.lock || -f bun.lockb ]]; then
+  echo "[deps] bun lockfile detected -> bun install --frozen-lockfile"
+  exec bun install --frozen-lockfile "$@"
+elif [[ -f pnpm-lock.yaml ]]; then
+  echo "[deps] pnpm lockfile detected -> corepack pnpm install --frozen-lockfile"
+  corepack enable >/dev/null 2>&1 || true
+  exec corepack pnpm install --frozen-lockfile "$@"
+elif [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then
+  echo "[deps] npm lockfile detected -> npm ci"
+  exec npm ci "$@"
+elif [[ -f yarn.lock ]]; then
+  echo "[deps] yarn lockfile detected -> corepack yarn install --frozen-lockfile"
+  corepack enable >/dev/null 2>&1 || true
+  exec corepack yarn install --frozen-lockfile "$@"
+else
+  echo "[deps] no known lockfile found -> uv sync --group dev"
+  exec uv sync --group dev "$@"
+fi

--- a/uv.lock
+++ b/uv.lock
@@ -946,6 +946,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "coverage" },
     { name = "mutmut" },
     { name = "pytest" },
     { name = "pytest-anyio" },
@@ -978,6 +979,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "coverage", specifier = ">=7.13.1" },
     { name = "mutmut", specifier = ">=3.4.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-anyio", specifier = ">=0.0.0" },


### PR DESCRIPTION
**Agent:** GPT-5.3 Codex

**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

## Summary
Add a lockfile-driven dependency bootstrap script to make local setup predictable across package managers, and fix a dev dependency gap that breaks `uv run pytest` with `pytest-cov`.

## Original Request
> [Thu 2026-02-12 00:35 UTC] Continue from handoff file /root/clawd/PARA/Projects/ops/HANDOFF_2026-02-12_0028Z.md.
>
> Requirements:
> - Use repo-by-repo checkpoints and append progress to that handoff file.
> - Prioritize owned repos first: /root/clawd/dev/Etc-mono-repo and /root/clawd/dev/takopi.
> - Implement universal package-manager usability (bun/pnpm/npm) in owned repos with lockfile-driven install script and packageManager hints where appropriate.
> - Clean accidental untracked noise from commits.
> - Run required validations per repo rules.
> - Open PRs with proper templates/attribution and return links.
> - Nightshift: verify and fix service/timer reliability, then verify doctor + dry-run + targeted run.
> - Final output: concise status + PR links + exact Nightshift state.

## Changes Made
- Added `scripts/install-deps.sh` lockfile router:
  - `uv.lock` → `uv sync --group dev`
  - `bun.lock*` → `bun install --frozen-lockfile`
  - `pnpm-lock.yaml` → `corepack pnpm install --frozen-lockfile`
  - `package-lock.json`/`npm-shrinkwrap.json` → `npm ci`
  - `yarn.lock` → `corepack yarn install --frozen-lockfile`
- Documented bootstrap command in `readme.md` development section.
- Added explicit `coverage>=7.13.1` to dev dependency group to resolve `uv run pytest` startup failure (`ModuleNotFoundError: coverage` via `pytest-cov`).
- Regenerated `uv.lock`.

## Testing & Verification
- `bash scripts/install-deps.sh`
- `uv run ruff format --check src tests`
- `uv run ruff check src tests`
- `uv run ty check src tests`
- `uv run pytest` (550 passed, coverage gate met)

## Notes
- Scope intentionally excludes unrelated local noise files.
