### PR TITLE
feat(telegram): add progress_updates and show_typing settings

### DIFF
--- a/src/takopi/__init__.py
+++ b/src/takopi/__init__.py
@@ -1,3 +1,6 @@
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = version("takopi")
+try:
+    __version__ = version("takopi")
+except PackageNotFoundError:
+    __version__ = "0.0.0.dev0+local"

--- a/src/takopi/runner_bridge.py
+++ b/src/takopi/runner_bridge.py
@@ -474,9 +474,8 @@ async def handle_message(
         thread_id=incoming.thread_id,
     )
 
-    running_task: RunningTask | None = None
+    running_task = RunningTask(context=context)
     if running_tasks is not None and progress_ref is not None:
-        running_task = RunningTask(context=context)
         running_tasks[progress_ref] = running_task
 
     cancel_exc_type = anyio.get_cancelled_exc_class()
@@ -514,10 +513,9 @@ async def handle_message(
                 error_type=exc.__class__.__name__,
             )
         finally:
-            if running_task is not None and running_tasks is not None:
-                running_task.done.set()
-                if progress_ref is not None:
-                    running_tasks.pop(progress_ref, None)
+            running_task.done.set()
+            if running_tasks is not None and progress_ref is not None:
+                running_tasks.pop(progress_ref, None)
             if not outcome.cancelled and error is None:
                 # Give pending progress edits a chance to flush if they're ready.
                 await anyio.sleep(0)

--- a/src/takopi/runner_bridge.py
+++ b/src/takopi/runner_bridge.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from typing import Literal
 
 import anyio
 
@@ -85,6 +86,8 @@ class ExecBridgeConfig:
     transport: Transport
     presenter: Presenter
     final_notify: bool
+    progress_updates: Literal["full", "once", "none"] = "full"
+    show_typing: bool = False
 
 
 @dataclass(slots=True)
@@ -165,6 +168,9 @@ class ProgressEdits:
         resume_formatter: Callable[[ResumeToken], str] | None = None,
         label: str = "working",
         context_line: str | None = None,
+        progress_updates: Literal["full", "once", "none"] = "full",
+        show_typing: bool = False,
+        thread_id: ThreadId | None = None,
     ) -> None:
         self.transport = transport
         self.presenter = presenter
@@ -177,11 +183,23 @@ class ProgressEdits:
         self.resume_formatter = resume_formatter
         self.label = label
         self.context_line = context_line
+        self.progress_updates = progress_updates
+        self.show_typing = show_typing
+        self.thread_id = thread_id
         self.event_seq = 0
         self.rendered_seq = 0
         self.signal_send, self.signal_recv = anyio.create_memory_object_stream(1)
 
-    async def run(self) -> None:
+    async def _typing_loop(self) -> None:
+        while True:
+            await self.transport.send_action(
+                channel_id=self.channel_id,
+                action="typing",
+                thread_id=self.thread_id,
+            )
+            await anyio.sleep(4.0)
+
+    async def _render_loop(self) -> None:
         if self.progress_ref is None:
             return
         while True:
@@ -216,6 +234,14 @@ class ProgressEdits:
                     self.last_rendered = rendered
 
             self.rendered_seq = seq_at_render
+
+    async def run(self) -> None:
+        async with anyio.create_task_group() as tg:
+            if self.show_typing:
+                tg.start_soon(self._typing_loop)
+
+            if self.progress_updates == "full" and self.progress_ref is not None:
+                tg.start_soon(self._render_loop)
 
     async def on_event(self, evt: TakopiEvent) -> None:
         if not self.tracker.note_event(evt):
@@ -416,17 +442,19 @@ async def handle_message(
         channel_id=incoming.channel_id,
         message_id=incoming.message_id,
     )
-    progress_state = await send_initial_progress(
-        cfg,
-        channel_id=incoming.channel_id,
-        reply_to=user_ref,
-        label="starting",
-        tracker=progress_tracker,
-        progress_ref=progress_ref,
-        resume_formatter=runner.format_resume,
-        context_line=context_line,
-        thread_id=incoming.thread_id,
-    )
+    progress_state = ProgressMessageState(ref=None, last_rendered=None)
+    if cfg.progress_updates != "none":
+        progress_state = await send_initial_progress(
+            cfg,
+            channel_id=incoming.channel_id,
+            reply_to=user_ref,
+            label="starting",
+            tracker=progress_tracker,
+            progress_ref=progress_ref,
+            resume_formatter=runner.format_resume,
+            context_line=context_line,
+            thread_id=incoming.thread_id,
+        )
     progress_ref = progress_state.ref
 
     edits = ProgressEdits(
@@ -438,8 +466,12 @@ async def handle_message(
         started_at=started_at,
         clock=clock,
         last_rendered=progress_state.last_rendered,
+
         resume_formatter=runner.format_resume,
         context_line=context_line,
+        progress_updates=cfg.progress_updates,
+        show_typing=cfg.show_typing,
+        thread_id=incoming.thread_id,
     )
 
     running_task: RunningTask | None = None
@@ -462,7 +494,7 @@ async def handle_message(
     error: Exception | None = None
 
     async with anyio.create_task_group() as tg:
-        if progress_ref is not None:
+        if progress_ref is not None or cfg.show_typing:
             tg.start_soon(run_edits)
 
         try:

--- a/src/takopi/settings.py
+++ b/src/takopi/settings.py
@@ -106,6 +106,8 @@ class TelegramTransportSettings(BaseModel):
     forward_coalesce_s: float = Field(default=1.0, ge=0)
     media_group_debounce_s: float = Field(default=1.0, ge=0)
     topics: TelegramTopicsSettings = Field(default_factory=TelegramTopicsSettings)
+    progress_updates: Literal["full", "once", "none"] = "full"
+    show_typing: bool = False
     files: TelegramFilesSettings = Field(default_factory=TelegramFilesSettings)
 
 

--- a/src/takopi/telegram/backend.py
+++ b/src/takopi/telegram/backend.py
@@ -126,6 +126,8 @@ class TelegramBackend(TransportBackend):
             transport=transport,
             presenter=presenter,
             final_notify=final_notify,
+            progress_updates=settings.progress_updates,
+            show_typing=settings.show_typing,
         )
         cfg = TelegramBridgeConfig(
             bot=bot,

--- a/src/takopi/telegram/bridge.py
+++ b/src/takopi/telegram/bridge.py
@@ -297,6 +297,19 @@ class TelegramTransport:
             message_id=cast(int, ref.message_id),
         )
 
+    async def send_action(
+        self,
+        *,
+        channel_id: int | str,
+        action: str = "typing",
+        thread_id: int | str | None = None,
+    ) -> bool:
+        return await self._bot.send_chat_action(
+            chat_id=cast(int, channel_id),
+            action=action,
+            message_thread_id=cast(int | None, thread_id),
+        )
+
 
 async def send_plain(
     transport: Transport,

--- a/src/takopi/telegram/client.py
+++ b/src/takopi/telegram/client.py
@@ -407,3 +407,26 @@ class TelegramClient:
                 chat_id=chat_id,
             )
         )
+
+    async def send_chat_action(
+        self,
+        chat_id: int,
+        action: str,
+        message_thread_id: int | None = None,
+    ) -> bool:
+        async def execute() -> bool:
+            return await self._client.send_chat_action(
+                chat_id,
+                action,
+                message_thread_id=message_thread_id,
+            )
+
+        return bool(
+            await self.enqueue_op(
+                key=self.unique_key("send_chat_action"),
+                label="send_chat_action",
+                execute=execute,
+                priority=SEND_PRIORITY,
+                chat_id=chat_id,
+            )
+        )

--- a/src/takopi/telegram/client_api.py
+++ b/src/takopi/telegram/client_api.py
@@ -126,6 +126,13 @@ class BotClient(Protocol):
         name: str,
     ) -> bool: ...
 
+    async def send_chat_action(
+        self,
+        chat_id: int,
+        action: str,
+        message_thread_id: int | None = None,
+    ) -> bool: ...
+
 
 class HttpBotClient:
     def __init__(
@@ -536,4 +543,16 @@ class HttpBotClient:
                 "name": name,
             },
         )
+        return bool(result)
+
+    async def send_chat_action(
+        self,
+        chat_id: int,
+        action: str,
+        message_thread_id: int | None = None,
+    ) -> bool:
+        params: dict[str, Any] = {"chat_id": chat_id, "action": action}
+        if message_thread_id is not None:
+            params["message_thread_id"] = message_thread_id
+        result = await self._post("sendChatAction", params)
         return bool(result)

--- a/src/takopi/telegram/loop.py
+++ b/src/takopi/telegram/loop.py
@@ -862,6 +862,8 @@ async def _send_queued_progress(
     resume_token: ResumeToken,
     context: RunContext | None,
 ) -> MessageRef | None:
+    if cfg.exec_cfg.progress_updates == "none":
+        return None
     tracker = ProgressTracker(engine=resume_token.engine)
     tracker.set_resume(resume_token)
     context_line = cfg.runtime.format_context_line(context)

--- a/src/takopi/transport.py
+++ b/src/takopi/transport.py
@@ -51,3 +51,11 @@ class Transport(Protocol):
     ) -> MessageRef | None: ...
 
     async def delete(self, *, ref: MessageRef) -> bool: ...
+
+    async def send_action(
+        self,
+        *,
+        channel_id: ChannelId,
+        action: str = "typing",
+        thread_id: ThreadId | None = None,
+    ) -> bool: ...

--- a/tests/test_runner_bridge_progress.py
+++ b/tests/test_runner_bridge_progress.py
@@ -1,0 +1,196 @@
+import pytest
+import anyio
+from takopi.runner_bridge import ExecBridgeConfig, IncomingMessage, handle_message
+from takopi.markdown import MarkdownPresenter
+from takopi.model import TakopiEvent
+from takopi.runners.mock import Advance, Emit, Return, ScriptRunner, Sleep
+from takopi.transport import MessageRef, RenderedMessage, SendOptions
+from tests.factories import action_started
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self._next_id = 1
+        self.send_calls: list[dict] = []
+        self.edit_calls: list[dict] = []
+        self.delete_calls: list[MessageRef] = []
+        self.action_calls: list[dict] = []
+
+    async def send(
+        self,
+        *,
+        channel_id: int | str,
+        message: RenderedMessage,
+        options: SendOptions | None = None,
+    ) -> MessageRef:
+        ref = MessageRef(channel_id=channel_id, message_id=self._next_id)
+        self._next_id += 1
+        self.send_calls.append(
+            {
+                "ref": ref,
+                "channel_id": channel_id,
+                "message": message,
+                "options": options,
+            }
+        )
+        return ref
+
+    async def edit(
+        self, *, ref: MessageRef, message: RenderedMessage, wait: bool = True
+    ) -> MessageRef:
+        self.edit_calls.append({"ref": ref, "message": message, "wait": wait})
+        return ref
+
+    async def delete(self, *, ref: MessageRef) -> bool:
+        self.delete_calls.append(ref)
+        return True
+
+    async def send_action(
+        self,
+        *,
+        channel_id: int | str,
+        action: str = "typing",
+        thread_id: int | str | None = None,
+    ) -> bool:
+        self.action_calls.append({"channel_id": channel_id, "action": action})
+        return True
+
+    async def close(self) -> None:
+        return None
+
+class _FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self._now = start
+
+    def __call__(self) -> float:
+        return self._now
+
+    def set(self, value: float) -> None:
+        self._now = value
+
+@pytest.mark.anyio
+async def test_progress_full_updates() -> None:
+    transport = FakeTransport()
+    clock = _FakeClock()
+    events = [action_started("item_0", "cmd", "echo 1")]
+    runner = ScriptRunner(
+        [Emit(events[0], at=0.2), Advance(1.0), Return("ok")],
+        engine="mock",
+        advance=clock.set,
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport,
+        presenter=MarkdownPresenter(),
+        final_notify=True,
+        progress_updates="full",
+        show_typing=False,
+    )
+
+    await handle_message(
+        cfg,
+        runner=runner,
+        incoming=IncomingMessage(channel_id=123, message_id=10, text="hi"),
+        resume_token=None,
+        clock=clock,
+    )
+
+    # Should have initial send + edits
+    assert len(transport.send_calls) >= 1
+    assert "starting" in transport.send_calls[0]["message"].text
+    assert transport.edit_calls
+    assert "working" in transport.edit_calls[-1]["message"].text
+
+@pytest.mark.anyio
+async def test_progress_once_no_intermediate_edits() -> None:
+    transport = FakeTransport()
+    clock = _FakeClock()
+    events = [action_started("item_0", "cmd", "echo 1")]
+    runner = ScriptRunner(
+        [Emit(events[0], at=0.2), Advance(1.0), Return("ok")],
+        engine="mock",
+        advance=clock.set,
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport,
+        presenter=MarkdownPresenter(),
+        final_notify=True,
+        progress_updates="once",
+        show_typing=False,
+    )
+
+    await handle_message(
+        cfg,
+        runner=runner,
+        incoming=IncomingMessage(channel_id=123, message_id=10, text="hi"),
+        resume_token=None,
+        clock=clock,
+    )
+
+    # Should have initial send
+    assert len(transport.send_calls) >= 1
+    assert "starting" in transport.send_calls[0]["message"].text
+    
+    # But NO edits during run (except maybe final if final_notify is False, but here True)
+    # The runner bridge logic does final edit/send.
+    # We want to ensure NO intermediate edits that say "working".
+    working_edits = [
+        c for c in transport.edit_calls 
+        if "working" in c["message"].text and "done" not in c["message"].text
+    ]
+    assert not working_edits
+
+@pytest.mark.anyio
+async def test_progress_none_sends_no_initial() -> None:
+    transport = FakeTransport()
+    runner = ScriptRunner([Return("ok")], engine="mock")
+    cfg = ExecBridgeConfig(
+        transport=transport,
+        presenter=MarkdownPresenter(),
+        final_notify=True,
+        progress_updates="none",
+        show_typing=False,
+    )
+
+    await handle_message(
+        cfg,
+        runner=runner,
+        incoming=IncomingMessage(channel_id=123, message_id=10, text="hi"),
+        resume_token=None,
+    )
+
+    # No initial "starting" message
+    initial_sends = [c for c in transport.send_calls if "starting" in c["message"].text]
+    assert not initial_sends
+    # Should send final result
+    assert transport.send_calls
+    assert "done" in transport.send_calls[-1]["message"].text or "ok" in transport.send_calls[-1]["message"].text
+
+@pytest.mark.anyio
+async def test_show_typing_sends_actions() -> None:
+    transport = FakeTransport()
+    runner = ScriptRunner([Sleep(0.1), Return("ok")], engine="mock")
+    cfg = ExecBridgeConfig(
+        transport=transport,
+        presenter=MarkdownPresenter(),
+        final_notify=True,
+        progress_updates="none", # Even with none, typing should work?
+        show_typing=True,
+    )
+
+    # We need to ensure the loop runs at least once. 4s sleep is long.
+    # Mocks don't advance time for anyio.sleep.
+    # Logic uses anyio.sleep(4.0).
+    # To test this without waiting 4s, we'd need to mock sleep or use TestRunner with fake time?
+    # runner_bridge uses `anyio.sleep`.
+    # Since we can't easily mock anyio.sleep here without complex setup, 
+    # we might rely on the fact that the first action is sent immediately?
+    # Wait, the loop is: `while True: send; sleep`. So first one sends immediately.
+    
+    await handle_message(
+        cfg,
+        runner=runner,
+        incoming=IncomingMessage(channel_id=123, message_id=10, text="hi"),
+        resume_token=None,
+    )
+
+    assert transport.action_calls
+    assert transport.action_calls[0]["action"] == "typing"

--- a/tests/test_settings_custom.py
+++ b/tests/test_settings_custom.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from takopi.settings import load_settings
+
+def test_telegram_transport_settings_defaults(tmp_path: Path) -> None:
+    config_path = tmp_path / "takopi.toml"
+    config_path.write_text(
+        'transport = "telegram"\n'
+        '[transports.telegram]\n'
+        'bot_token = "token"\n'
+        'chat_id = 123\n',
+        encoding="utf-8",
+    )
+    settings, _ = load_settings(config_path)
+    tg_settings = settings.transports.telegram
+    assert tg_settings.progress_updates == "full"
+    assert tg_settings.show_typing is False
+
+def test_telegram_transport_settings_custom(tmp_path: Path) -> None:
+    config_path = tmp_path / "takopi.toml"
+    config_path.write_text(
+        'transport = "telegram"\n'
+        '[transports.telegram]\n'
+        'bot_token = "token"\n'
+        'chat_id = 123\n'
+        'progress_updates = "once"\n'
+        'show_typing = true\n',
+        encoding="utf-8",
+    )
+    settings, _ = load_settings(config_path)
+    tg_settings = settings.transports.telegram
+    assert tg_settings.progress_updates == "once"
+    assert tg_settings.show_typing is True


### PR DESCRIPTION
# feat(telegram): add `progress_updates` and [show_typing](tests/test_runner_bridge_progress.py#L167-L197) configuration settings

## Description

This PR introduces new configuration options to the [TelegramTransport](src/takopi/telegram/bridge.py#L137-L312) to allow finer control over user feedback during long-running operations. Currently, the transport defaults to streaming full progress updates, which can be noisy in certain contexts.

### Key Changes

1.  **Added `progress_updates` setting**:
    -   Controls the frequency of progress messages sent to the user.
    -   **Options**:
        -   `"full"` (default): retains existing behavior (streaming updates).
        -   `"once"`: sends an initial "working" message but suppresses subsequent intermediate updates until completion.
        -   `"none"`: suppresses all progress messages; only the final result is sent.

2.  **Added [show_typing](tests/test_runner_bridge_progress.py#L167-L197) setting**:
    -   **Type**: `bool` (default: `False`).
    -   When enabled, the bot sends a continuous "typing" action to the chat while processing, providing a subtle visual cue to the user without decluttering the chat history with messages.

3.  **Implementation**:
    -   Updated [TelegramTransportSettings](src/takopi/settings.py#L92-L112) in [src/takopi/settings.py](src/takopi/settings.py).
    -   Extended [BotClient](src/takopi/telegram/client_api.py#L36-L135) protocol and implementations ([HttpBotClient](src/takopi/telegram/client_api.py#L137-L559), [TelegramClient](src/takopi/telegram/client.py#L39-L433)) to support [send_chat_action](src/takopi/telegram/client_api.py#L129-L135).
    -   Modified [ProgressEdits](src/takopi/runner_bridge.py#L156-L258) logic in [src/takopi/runner_bridge.py](src/takopi/runner_bridge.py) to respect the new settings.
    -   Added a background loop to maintain the "typing" status if enabled.

4.  **Fixes**:
    -   Improved `takopi.__init__` version retrieval to gracefully handle cases where the package is not installed (e.g., during local development), preventing `PackageNotFoundError`.

### Verification

-   Added unit tests in [tests/test_settings_custom.py](tests/test_settings_custom.py) to verify configuration loading and defaults.
-   Added unit tests in [tests/test_runner_bridge_progress.py](tests/test_runner_bridge_progress.py) to verify the logic for all three `progress_updates` modes and the [show_typing](tests/test_runner_bridge_progress.py#L167-L197) behavior.
-   Ran full test suite to ensure no regressions.

---

**Checklist**

-   [x] Tests passed.
-   [x] Code style and linting checked.
-   [x] Backward compatibility maintained (defaults match previous behavior).