### PR TITLE
feat: show Claude Code version and model in Telegram footer

### DIFF
--- a/src/takopi/markdown.py
+++ b/src/takopi/markdown.py
@@ -188,15 +188,34 @@ def render_event_cli(event: TakopiEvent) -> list[str]:
             return []
 
 
+def shorten_model(model: str) -> str:
+    """Shorten a Claude model ID for display.
+
+    ``claude-opus-4-6`` → ``opus 4.6``
+    ``claude-sonnet-4-5-20250929`` → ``sonnet 4.5``
+    """
+    import re
+
+    m = re.match(
+        r"^claude-(\w+)-(\d+)-(\d+)(?:-\d+)?$",
+        model,
+    )
+    if m:
+        return f"{m.group(1)} {m.group(2)}.{m.group(3)}"
+    return model
+
+
 class MarkdownFormatter:
     def __init__(
         self,
         *,
         max_actions: int = 5,
         command_width: int | None = MAX_PROGRESS_CMD_LEN,
+        show_runner_version: bool = False,
     ) -> None:
         self.max_actions = max(0, int(max_actions))
         self.command_width = command_width
+        self.show_runner_version = show_runner_version
 
     def render_progress_parts(
         self,
@@ -240,6 +259,14 @@ class MarkdownFormatter:
 
     def _format_footer(self, state: ProgressState) -> str | None:
         lines: list[str] = []
+        if self.show_runner_version:
+            info_parts: list[str] = []
+            if state.runner_version:
+                info_parts.append(f"claude code {state.runner_version}")
+            if state.model:
+                info_parts.append(shorten_model(state.model))
+            if info_parts:
+                lines.append(HEADER_SEP.join(info_parts))
         if state.context_line:
             lines.append(state.context_line)
         if state.resume_line:

--- a/src/takopi/progress.py
+++ b/src/takopi/progress.py
@@ -25,11 +25,17 @@ class ProgressState:
     resume: ResumeToken | None
     resume_line: str | None
     context_line: str | None
+    runner_version: str | None = None
+    model: str | None = None
 
 
 class ProgressTracker:
-    def __init__(self, *, engine: str) -> None:
+    def __init__(
+        self, *, engine: str, runner_version: str | None = None
+    ) -> None:
         self.engine = engine
+        self.runner_version = runner_version
+        self.model: str | None = None
         self.resume: ResumeToken | None = None
         self.action_count = 0
         self._actions: dict[str, ActionState] = {}
@@ -37,8 +43,10 @@ class ProgressTracker:
 
     def note_event(self, event: TakopiEvent) -> bool:
         match event:
-            case StartedEvent(resume=resume):
+            case StartedEvent(resume=resume, meta=meta):
                 self.resume = resume
+                if isinstance(meta, dict) and "model" in meta:
+                    self.model = meta["model"]
                 return True
             case ActionEvent(action=action, phase=phase, ok=ok):
                 if action.kind == "turn":
@@ -96,4 +104,6 @@ class ProgressTracker:
             resume=self.resume,
             resume_line=resume_line,
             context_line=context_line,
+            runner_version=self.runner_version,
+            model=self.model,
         )

--- a/src/takopi/runner_bridge.py
+++ b/src/takopi/runner_bridge.py
@@ -85,6 +85,7 @@ class ExecBridgeConfig:
     transport: Transport
     presenter: Presenter
     final_notify: bool
+    show_runner_version: bool = False
 
 
 @dataclass(slots=True)
@@ -410,7 +411,10 @@ async def handle_message(
     resume_strip = strip_resume_line or is_resume_line
     runner_text = _strip_resume_lines(incoming.text, is_resume_line=resume_strip)
 
-    progress_tracker = ProgressTracker(engine=runner.engine)
+    runner_version = getattr(runner, "cli_version", None) if cfg.show_runner_version else None
+    progress_tracker = ProgressTracker(
+        engine=runner.engine, runner_version=runner_version
+    )
 
     user_ref = MessageRef(
         channel_id=incoming.channel_id,

--- a/src/takopi/runners/claude.py
+++ b/src/takopi/runners/claude.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -181,6 +182,8 @@ def translate_claude_event(
                 if value is not None:
                     meta[key] = value
             model = event.model
+            if isinstance(model, str) and model:
+                meta["model"] = model
             token = ResumeToken(engine=ENGINE, value=session_id)
             event_title = str(model) if isinstance(model, str) and model else title
             return [factory.started(token, title=event_title, meta=meta or None)]
@@ -278,6 +281,21 @@ def translate_claude_event(
             return []
 
 
+def _detect_cli_version(cmd: str) -> str | None:
+    try:
+        result = subprocess.run(
+            [cmd, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
 @dataclass(slots=True)
 class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
     engine: EngineId = ENGINE
@@ -290,6 +308,15 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
     use_api_billing: bool = False
     session_title: str = "claude"
     logger = logger
+    _cli_version: str | None = field(default=None, repr=False)
+    _cli_version_detected: bool = field(default=False, repr=False)
+
+    @property
+    def cli_version(self) -> str | None:
+        if not self._cli_version_detected:
+            self._cli_version = _detect_cli_version(self.claude_cmd)
+            self._cli_version_detected = True
+        return self._cli_version
 
     def format_resume(self, token: ResumeToken) -> str:
         if token.engine != ENGINE:

--- a/src/takopi/settings.py
+++ b/src/takopi/settings.py
@@ -103,6 +103,7 @@ class TelegramTransportSettings(BaseModel):
     voice_transcription_api_key: NonEmptyStr | None = None
     session_mode: Literal["stateless", "chat"] = "stateless"
     show_resume_line: bool = True
+    show_runner_version: bool = False
     forward_coalesce_s: float = Field(default=1.0, ge=0)
     media_group_debounce_s: float = Field(default=1.0, ge=0)
     topics: TelegramTopicsSettings = Field(default_factory=TelegramTopicsSettings)

--- a/src/takopi/telegram/backend.py
+++ b/src/takopi/telegram/backend.py
@@ -121,11 +121,15 @@ class TelegramBackend(TransportBackend):
         )
         bot = TelegramClient(token)
         transport = TelegramTransport(bot)
-        presenter = TelegramPresenter(message_overflow=settings.message_overflow)
+        presenter = TelegramPresenter(
+            message_overflow=settings.message_overflow,
+            show_runner_version=settings.show_runner_version,
+        )
         exec_cfg = ExecBridgeConfig(
             transport=transport,
             presenter=presenter,
             final_notify=final_notify,
+            show_runner_version=settings.show_runner_version,
         )
         cfg = TelegramBridgeConfig(
             bot=bot,

--- a/src/takopi/telegram/bridge.py
+++ b/src/takopi/telegram/bridge.py
@@ -49,8 +49,11 @@ class TelegramPresenter:
         *,
         formatter: MarkdownFormatter | None = None,
         message_overflow: str = "trim",
+        show_runner_version: bool = False,
     ) -> None:
-        self._formatter = formatter or MarkdownFormatter()
+        self._formatter = formatter or MarkdownFormatter(
+            show_runner_version=show_runner_version,
+        )
         self._message_overflow = message_overflow
 
     def render_progress(


### PR DESCRIPTION
## Summary

- Add opt-in `show_runner_version` setting (default: off) to display Claude Code CLI version and model in the message footer
- When enabled, footer shows a line like `claude code 2.1.50 · opus 4.6`
- CLI version detected via `claude --version` (cached, lazy, only called when setting is on)
- Model extracted from `StreamSystemMessage` into `StartedEvent.meta["model"]`
- Model IDs shortened for display (`claude-opus-4-6` → `opus 4.6`)
- Scoped to Claude Code runner only; other runners unaffected

## Config

```toml
[transports.telegram]
show_runner_version = true
```

## Output

```
success · claude · 5s · 3 steps
[body]
claude code 2.1.50 · opus 4.6
```