### PR TITLE
fix: deny root-level files with default deny_globs

### DIFF
--- a/src/takopi/settings.py
+++ b/src/takopi/settings.py
@@ -76,8 +76,8 @@ class TelegramFilesSettings(BaseModel):
             ".git/**",
             ".env",
             ".envrc",
-            "**/*.pem",
-            "**/.ssh/**",
+            "*.pem",
+            ".ssh/**",
         ]
     )
 

--- a/tests/test_telegram_files.py
+++ b/tests/test_telegram_files.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from takopi.settings import TelegramFilesSettings
 from takopi.telegram import files as tg_files
 from takopi.telegram.files import ZipTooLargeError, zip_directory
 
@@ -98,6 +99,14 @@ def test_resolve_path_within_root_rejects_escape(tmp_path: Path) -> None:
 def test_deny_reason_matches_patterns() -> None:
     assert tg_files.deny_reason(Path(".git/config"), ["**/*.pem"]) == ".git/**"
     assert tg_files.deny_reason(Path("secrets/key.pem"), ["**/*.pem"]) == "**/*.pem"
+
+
+def test_default_deny_globs_cover_sensitive_paths() -> None:
+    patterns = TelegramFilesSettings().deny_globs
+    assert tg_files.deny_reason(Path("key.pem"), patterns) == "*.pem"
+    assert tg_files.deny_reason(Path(".ssh/id_rsa"), patterns) == ".ssh/**"
+    assert tg_files.deny_reason(Path("secrets/key.pem"), patterns) == "*.pem"
+    assert tg_files.deny_reason(Path("configs/.ssh/id_rsa"), patterns) == ".ssh/**"
 
 
 def test_format_bytes_various_units() -> None:


### PR DESCRIPTION
Currently with default deny list `*.pem` and `.ssh/**` files in the project root are downloadable which is misleading given there are deny globs for them.