### PR TITLE
feat: sync github issues with telegram topics

### DIFF
--- a/docs/how-to/topics.md
+++ b/docs/how-to/topics.md
@@ -84,6 +84,37 @@ Use `/agent set` inside the topic:
 /agent set claude
 ```
 
+## Create topics from GitHub issues
+
+The `/issues` command (in Telegram) and `takopi issues sync` (CLI) fetch open issues from the project's GitHub repo and create a topic per issue. Each topic is bound to a branch named `issue/<number>`.
+
+### From Telegram
+
+Inside a topics-enabled chat:
+
+```
+/issues sync
+/issues sync myproject
+/issues sync -label=bug -limit=5
+```
+
+### From the CLI
+
+```sh
+takopi issues sync
+takopi issues sync --project=myproject --label=bug --limit=10
+takopi issues sync --dry-run  # preview without creating
+```
+
+### How it works
+
+1. Derives `owner/repo` from the project's git remote
+2. Fetches open issues via the GitHub API (uses `GITHUB_TOKEN` or `gh auth token`)
+3. For each issue, creates a forum topic named `project @issue/42`
+4. Skips issues that already have a bound topic
+
+When you send a message in one of these topics, takopi will resolve the context and run the agent in the corresponding `issue/<number>` worktree.
+
 ## State files
 
 Topic bindings and sessions live in:

--- a/src/takopi/cli/__init__.py
+++ b/src/takopi/cli/__init__.py
@@ -58,6 +58,7 @@ from .init import (
     run_init,
 )
 from .onboarding_cmd import chat_id, onboarding_paths
+from .issues import create_issues_app
 from .plugins import plugins_cmd
 from .run import (
     _default_engine_for_setup,
@@ -173,6 +174,7 @@ def create_app() -> typer.Typer:
     app.command(name="onboarding-paths")(onboarding_paths)
     app.command(name="plugins")(plugins_cmd)
     app.add_typer(config_app, name="config")
+    app.add_typer(create_issues_app(), name="issues")
     app.callback()(app_main)
     for engine_id in _engine_ids_for_cli():
         help_text = f"Run with the {engine_id} engine."

--- a/src/takopi/cli/issues.py
+++ b/src/takopi/cli/issues.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from functools import partial
+from pathlib import Path
+
+import anyio
+import typer
+
+from ..config import ConfigError, ProjectConfig
+from ..github import GitHubError, fetch_issues, issue_branch_name, parse_github_remote
+from ..logging import get_logger, setup_logging
+from ..settings import load_settings
+
+logger = get_logger(__name__)
+
+
+def _load_project(
+    project: str | None,
+) -> tuple[str, Path, int | None, ProjectConfig]:
+    """Load settings and resolve a project. Returns (project_key, project_path, chat_id)."""
+    settings, config_path = load_settings()
+    from ..engines import list_backend_ids
+    from ..runtime_loader import resolve_plugins_allowlist
+
+    engine_ids = list_backend_ids(allowlist=resolve_plugins_allowlist(settings))
+    projects_config = settings.to_projects_config(
+        config_path=config_path, engine_ids=engine_ids
+    )
+
+    if project is not None:
+        project_key = project.lower()
+    else:
+        # try to match cwd against configured project paths
+        cwd = Path.cwd().resolve()
+        project_key = None
+        for key, proj in projects_config.projects.items():
+            if cwd == proj.path.resolve() or cwd.is_relative_to(proj.path.resolve()):
+                project_key = key
+                break
+        if project_key is None:
+            project_key = projects_config.default_project
+        if project_key is None:
+            raise ConfigError(
+                "no project specified and no default_project configured. "
+                "run `takopi init` first or pass --project."
+            )
+
+    proj = projects_config.projects.get(project_key)
+    if proj is None:
+        available = ", ".join(sorted(projects_config.projects))
+        raise ConfigError(
+            f"unknown project {project_key!r}. available: {available}"
+        )
+
+    tg = settings.transports.telegram
+    chat_id = proj.chat_id
+    if chat_id is None and tg is not None:
+        chat_id = tg.chat_id
+
+    return project_key, proj.path, chat_id, proj
+
+
+async def _run_issues_sync(
+    project: str | None,
+    labels: list[str] | None,
+    limit: int,
+    dry_run: bool,
+) -> None:
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+
+    try:
+        project_key, project_path, chat_id, project_cfg = _load_project(project)
+    except ConfigError as exc:
+        console.print(f"[red]error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    try:
+        owner, repo = parse_github_remote(project_path)
+    except GitHubError as exc:
+        console.print(f"[red]error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    console.print(f"fetching issues from [bold]{owner}/{repo}[/bold]...")
+
+    try:
+        issues = await fetch_issues(owner, repo, labels=labels)
+    except GitHubError as exc:
+        console.print(f"[red]error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    if not issues:
+        console.print("no open issues found.")
+        return
+
+    table = Table(title=f"issues for {owner}/{repo} ({len(issues)} open)")
+    table.add_column("#", style="cyan", justify="right")
+    table.add_column("title")
+    table.add_column("labels", style="dim")
+    table.add_column("branch", style="green")
+
+    for issue in issues:
+        labels_str = ", ".join(issue.labels) if issue.labels else ""
+        branch = issue_branch_name(issue.number)
+        table.add_row(str(issue.number), issue.title, labels_str, f"@{branch}")
+
+    console.print(table)
+
+    if dry_run:
+        console.print("[yellow]dry run — no topics created.[/yellow]")
+        return
+
+    if chat_id is None:
+        console.print(
+            "[red]error:[/red] no chat_id configured for this project or transport. "
+            "set projects.<alias>.chat_id or transports.telegram.chat_id."
+        )
+        raise typer.Exit(1)
+
+    from ..settings import load_settings as reload_settings
+    from ..telegram.client import TelegramClient
+    from ..telegram.issue_topics import create_topics_from_issues
+    from ..telegram.topic_state import TopicStateStore, resolve_state_path
+
+    settings, config_path = reload_settings()
+    tg = settings.transports.telegram
+    if tg is None:
+        console.print("[red]error:[/red] telegram transport not configured.")
+        raise typer.Exit(1)
+
+    if not tg.topics.enabled:
+        console.print("[red]error:[/red] topics are not enabled. set topics.enabled = true.")
+        raise typer.Exit(1)
+
+    bot_client = TelegramClient(tg.bot_token)
+    store = TopicStateStore(resolve_state_path(config_path))
+
+    try:
+        results = await create_topics_from_issues(
+            issues=issues,
+            project=project_key,
+            chat_id=chat_id,
+            bot=bot_client._client,
+            store=store,
+            project_config=project_cfg,
+            limit=limit,
+        )
+    finally:
+        await bot_client.close()
+
+    created = [r for r in results if not r.already_existed]
+    skipped = [r for r in results if r.already_existed]
+
+    if created:
+        console.print(f"[green]created {len(created)} topic(s):[/green]")
+        for r in created:
+            console.print(f"  #{r.issue.number} {r.issue.title}")
+    if skipped:
+        console.print(f"[dim]skipped {len(skipped)} existing topic(s)[/dim]")
+    if not created and not skipped:
+        console.print("[yellow]no topics created.[/yellow]")
+
+
+_PROJECT_OPTION = typer.Option(None, "--project", "-p", help="Project alias. Defaults to default_project.")
+_LABEL_OPTION = typer.Option(None, "--label", "-l", help="Filter issues by label (can be repeated).")
+_LIMIT_OPTION = typer.Option(30, "--limit", "-n", help="Maximum number of issues to fetch.")
+_DRY_RUN_OPTION = typer.Option(False, "--dry-run", help="Preview issues without creating topics.")
+
+
+def issues_sync(
+    project: str | None = _PROJECT_OPTION,
+    label: list[str] | None = _LABEL_OPTION,
+    limit: int = _LIMIT_OPTION,
+    dry_run: bool = _DRY_RUN_OPTION,
+) -> None:
+    """Fetch GitHub issues and create Telegram topics for each."""
+    setup_logging(debug=False, cache_logger_on_first_use=False)
+    anyio.run(partial(_run_issues_sync, project, label, limit, dry_run))
+
+
+def create_issues_app() -> typer.Typer:
+    app = typer.Typer(help="Manage GitHub issue topics.")
+    app.command(name="sync")(issues_sync)
+    return app

--- a/src/takopi/github.py
+++ b/src/takopi/github.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+from .logging import get_logger
+from .utils.git import git_stdout
+
+logger = get_logger(__name__)
+
+
+class GitHubError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubIssue:
+    number: int
+    title: str
+    labels: tuple[str, ...]
+    state: str
+    html_url: str
+
+
+def parse_github_remote(repo_path: Path) -> tuple[str, str]:
+    """Extract (owner, repo) from the git remote origin URL."""
+    url = git_stdout(["remote", "get-url", "origin"], cwd=repo_path)
+    if not url:
+        raise GitHubError("no git remote 'origin' found")
+    return _parse_owner_repo(url)
+
+
+def _parse_owner_repo(url: str) -> tuple[str, str]:
+    url = url.strip().removesuffix(".git")
+    if url.startswith("git@"):
+        # git@github.com:owner/repo
+        _, _, path = url.partition(":")
+    elif "github.com" in url:
+        # https://github.com/owner/repo
+        parts = url.split("github.com/", 1)
+        if len(parts) < 2:
+            raise GitHubError(f"cannot parse github remote: {url!r}")
+        path = parts[1]
+    else:
+        raise GitHubError(f"cannot parse github remote: {url!r}")
+    segments = path.strip("/").split("/")
+    if len(segments) < 2:
+        raise GitHubError(f"cannot parse owner/repo from: {url!r}")
+    return segments[0], segments[1]
+
+
+def _get_github_token() -> str | None:
+    """Try GITHUB_TOKEN env var, then `gh auth token`."""
+    import os
+    import subprocess
+
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        return token.strip()
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except FileNotFoundError:
+        pass
+    return None
+
+
+async def fetch_issues(
+    owner: str,
+    repo: str,
+    *,
+    labels: list[str] | None = None,
+    state: str = "open",
+    limit: int = 30,
+    token: str | None = None,
+) -> list[GitHubIssue]:
+    """Fetch all issues from a GitHub repository, applying *limit* locally."""
+    if token is None:
+        token = _get_github_token()
+
+    headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    params: dict[str, str | int] = {
+        "state": state,
+        "per_page": 100,
+        "sort": "created",
+        "direction": "desc",
+    }
+    if labels:
+        params["labels"] = ",".join(labels)
+
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues"
+    issues: list[GitHubIssue] = []
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        page = 1
+        while True:
+            resp = await client.get(
+                url, headers=headers, params={**params, "page": page}
+            )
+            if resp.status_code == 401:
+                raise GitHubError(
+                    "github authentication failed; set GITHUB_TOKEN or run `gh auth login`"
+                )
+            if resp.status_code == 404:
+                raise GitHubError(f"repository {owner}/{repo} not found")
+            resp.raise_for_status()
+            data = resp.json()
+            if not data:
+                break
+
+            for item in data:
+                # skip pull requests (they also appear in /issues)
+                if "pull_request" in item:
+                    continue
+                issue_labels = tuple(
+                    label["name"]
+                    for label in item.get("labels", [])
+                    if "name" in label
+                )
+                issues.append(
+                    GitHubIssue(
+                        number=item["number"],
+                        title=item["title"],
+                        labels=issue_labels,
+                        state=item["state"],
+                        html_url=item["html_url"],
+                    )
+                )
+
+            if len(data) < 100:
+                break
+            page += 1
+
+    return issues[:limit]
+
+
+def issue_branch_name(issue_number: int) -> str:
+    """Generate a branch name for a GitHub issue."""
+    return f"issue/{issue_number}"

--- a/src/takopi/ids.py
+++ b/src/takopi/ids.py
@@ -7,7 +7,7 @@ _ID_RE = re.compile(ID_PATTERN)
 
 RESERVED_CLI_COMMANDS = frozenset({"config", "doctor", "init", "plugins"})
 RESERVED_CHAT_COMMANDS = frozenset(
-    {"cancel", "file", "new", "agent", "model", "reasoning", "trigger", "topic", "ctx"}
+    {"cancel", "file", "new", "agent", "model", "reasoning", "trigger", "topic", "ctx", "issues"}
 )
 RESERVED_ENGINE_IDS = RESERVED_CLI_COMMANDS | RESERVED_CHAT_COMMANDS
 RESERVED_COMMAND_IDS = RESERVED_CLI_COMMANDS | RESERVED_CHAT_COMMANDS

--- a/src/takopi/telegram/client_api.py
+++ b/src/takopi/telegram/client_api.py
@@ -528,12 +528,28 @@ class HttpBotClient:
         message_thread_id: int,
         name: str,
     ) -> bool:
-        result = await self._post(
-            "editForumTopic",
-            {
-                "chat_id": chat_id,
-                "message_thread_id": message_thread_id,
-                "name": name,
-            },
-        )
-        return bool(result)
+        # Use _request directly so we can inspect the response body
+        # for "not modified" errors (topic exists but name unchanged).
+        json_data = {
+            "chat_id": chat_id,
+            "message_thread_id": message_thread_id,
+            "name": name,
+        }
+        logger.debug("telegram.request", method="editForumTopic", payload=json_data)
+        try:
+            resp = await self._http_client.post(
+                f"{self._base}/editForumTopic", json=json_data
+            )
+        except httpx.HTTPError:
+            return False
+        try:
+            payload = resp.json()
+        except Exception:  # noqa: BLE001
+            return resp.is_success
+        if isinstance(payload, dict) and payload.get("ok"):
+            return True
+        # "Bad Request: TOPIC_NOT_MODIFIED" means the topic exists.
+        description = payload.get("description", "") if isinstance(payload, dict) else ""
+        if "not_modified" in description.lower().replace(" ", "_"):
+            return True
+        return False

--- a/src/takopi/telegram/commands/handlers.py
+++ b/src/takopi/telegram/commands/handlers.py
@@ -7,6 +7,7 @@ from .dispatch import _dispatch_command as dispatch_command
 from .executor import _run_engine as run_engine
 from .executor import _should_show_resume_line as should_show_resume_line
 from .file_transfer import _handle_file_command as handle_file_command
+from .issues import _handle_issues_command as handle_issues_command
 from .file_transfer import _handle_file_put_default as handle_file_put_default
 from .file_transfer import _save_file_put as save_file_put
 from .media import _handle_media_group as handle_media_group
@@ -31,6 +32,7 @@ __all__ = [
     "handle_ctx_command",
     "handle_file_command",
     "handle_file_put_default",
+    "handle_issues_command",
     "handle_media_group",
     "handle_model_command",
     "handle_new_command",

--- a/src/takopi/telegram/commands/issues.py
+++ b/src/takopi/telegram/commands/issues.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ...config import ConfigError
+from ...context import RunContext
+from ...github import GitHubError, fetch_issues, issue_branch_name, parse_github_remote
+from ...logging import get_logger
+from ..files import split_command_args
+from ..issue_topics import create_topics_from_issues
+from ..topic_state import TopicStateStore
+from ..topics import _topics_chat_project, _topics_command_error
+from .reply import make_reply
+
+if TYPE_CHECKING:
+    from ..bridge import TelegramBridgeConfig
+    from ..types import TelegramIncomingMessage
+
+logger = get_logger(__name__)
+
+
+async def _handle_issues_command(
+    cfg: TelegramBridgeConfig,
+    msg: TelegramIncomingMessage,
+    args_text: str,
+    store: TopicStateStore,
+    *,
+    resolved_scope: str | None = None,
+    scope_chat_ids: frozenset[int] | None = None,
+) -> None:
+    reply = make_reply(cfg, msg)
+    error = _topics_command_error(
+        cfg,
+        msg.chat_id,
+        resolved_scope=resolved_scope,
+        scope_chat_ids=scope_chat_ids,
+    )
+    if error is not None:
+        await reply(text=error)
+        return
+
+    tokens = split_command_args(args_text)
+    action = tokens[0].lower() if tokens else "help"
+
+    if action == "help":
+        await reply(
+            text=(
+                "usage:\n"
+                "`/issues sync [project] [-label=X] [-limit=N]`\n"
+                "fetches github issues and creates a topic per issue."
+            )
+        )
+        return
+
+    if action != "sync":
+        await reply(text=f"unknown `/issues` action {action!r}. use `/issues sync`.")
+        return
+
+    # parse optional args: project, -label=X, -limit=N
+    rest = tokens[1:]
+    project_token: str | None = None
+    labels: list[str] = []
+    limit = 10
+
+    for token in rest:
+        if token.startswith("-label="):
+            labels.append(token.removeprefix("-label="))
+        elif token.startswith("-limit="):
+            try:
+                limit = int(token.removeprefix("-limit="))
+            except ValueError:
+                await reply(text="invalid -limit value")
+                return
+        elif project_token is None:
+            project_token = token
+        else:
+            await reply(text=f"unexpected argument: {token!r}")
+            return
+
+    # resolve project: explicit arg > topic context > chat project > default
+    chat_project = _topics_chat_project(cfg, msg.chat_id)
+    topic_project: str | None = None
+    if msg.thread_id is not None:
+        topic_ctx = await store.get_context(msg.chat_id, msg.thread_id)
+        if topic_ctx is not None:
+            topic_project = topic_ctx.project
+
+    if project_token is not None:
+        project_key = cfg.runtime.normalize_project_key(project_token)
+        if project_key is None:
+            await reply(text=f"unknown project {project_token!r}")
+            return
+    elif topic_project is not None:
+        project_key = topic_project
+    elif chat_project is not None:
+        project_key = chat_project
+    elif cfg.runtime.default_project is not None:
+        project_key = cfg.runtime.default_project
+    else:
+        await reply(text="no project specified and no default project configured.")
+        return
+
+    try:
+        project_path = cfg.runtime.resolve_run_cwd(
+            RunContext(project=project_key)
+        )
+    except ConfigError:
+        project_path = None
+    if project_path is None:
+        await reply(text=f"cannot resolve path for project {project_key!r}")
+        return
+
+    await reply(text="fetching github issues...")
+
+    try:
+        owner, repo = parse_github_remote(project_path)
+    except GitHubError as exc:
+        await reply(text=f"error: {exc}")
+        return
+
+    try:
+        issues = await fetch_issues(
+            owner,
+            repo,
+            labels=labels or None,
+        )
+    except GitHubError as exc:
+        await reply(text=f"error: {exc}")
+        return
+
+    if not issues:
+        await reply(text="no open issues found.")
+        return
+
+    results = await create_topics_from_issues(
+        issues=issues,
+        project=project_key,
+        chat_id=msg.chat_id,
+        bot=cfg.bot,
+        store=store,
+        project_alias=cfg.runtime.project_alias_for_key(project_key),
+        project_config=cfg.runtime.project_config_for_key(project_key),
+        transport=cfg.exec_cfg.transport,
+        limit=limit,
+    )
+
+    created = [r for r in results if not r.already_existed]
+    skipped = [r for r in results if r.already_existed]
+
+    parts: list[str] = []
+    if created:
+        header = f"**created {len(created)} topic(s):**"
+        items = "\n".join(
+            f"- @{issue_branch_name(r.issue.number)} — {r.issue.title}"
+            for r in created
+        )
+        parts.append(f"{header}\n\n{items}")
+    if skipped:
+        parts.append(f"skipped {len(skipped)} existing topic(s)")
+    if not created and not skipped:
+        parts.append("no topics created.")
+
+    await reply(text="\n\n".join(parts))

--- a/src/takopi/telegram/commands/menu.py
+++ b/src/takopi/telegram/commands/menu.py
@@ -83,7 +83,10 @@ def build_bot_commands(
         commands.append({"command": cmd, "description": description})
         seen.add(cmd)
     if include_topics:
-        for cmd, description in [("topic", "create or bind a topic")]:
+        for cmd, description in [
+            ("topic", "create or bind a topic"),
+            ("issues", "create topics from github issues"),
+        ]:
             if cmd in seen:
                 continue
             commands.append({"command": cmd, "description": description})

--- a/src/takopi/telegram/issue_topics.py
+++ b/src/takopi/telegram/issue_topics.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from ..config import ProjectConfig
+from ..context import RunContext
+from ..github import GitHubIssue, issue_branch_name
+from ..logging import get_logger
+from ..markdown import MarkdownParts
+from ..transport import RenderedMessage, SendOptions
+from ..worktrees import WorktreeError, ensure_worktree
+from .render import prepare_telegram
+from .topic_state import TopicStateStore
+
+if TYPE_CHECKING:
+    from ..transport import Transport
+    from .client_api import BotClient
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class CreatedIssueTopic:
+    issue: GitHubIssue
+    thread_id: int
+    already_existed: bool
+
+
+def issue_topic_title(issue: GitHubIssue, project: str | None = None) -> str:
+    """Generate a topic title for a GitHub issue.
+
+    Uses the same ``@branch`` pattern as manually created topics:
+    ``@issue/42`` or ``project @issue/42``.
+    """
+    branch = issue_branch_name(issue.number)
+    prefix = f"{project} " if project else ""
+    title = f"{prefix}@{branch}"
+    # Telegram topic names have a 128-char limit
+    if len(title) > 128:
+        title = title[:125] + "..."
+    return title
+
+
+async def create_topics_from_issues(
+    *,
+    issues: list[GitHubIssue],
+    project: str,
+    chat_id: int,
+    bot: BotClient,
+    store: TopicStateStore,
+    project_alias: str | None = None,
+    project_config: ProjectConfig | None = None,
+    transport: Transport | None = None,
+    limit: int | None = None,
+) -> list[CreatedIssueTopic]:
+    """Create Telegram forum topics for a list of GitHub issues.
+
+    Skips issues that already have a bound topic.  Stale bindings (topic
+    deleted from Telegram) are detected automatically and re-created.
+    When *limit* is set, stops after creating that many **new** topics.
+    """
+    results: list[CreatedIssueTopic] = []
+    created_count = 0
+    display_project = project_alias or project
+
+    for issue in issues:
+        branch = issue_branch_name(issue.number)
+        context = RunContext(project=project, branch=branch)
+        title = issue_topic_title(issue, display_project)
+
+        existing_thread = await store.find_thread_for_context(chat_id, context)
+        if existing_thread is not None:
+            # Verify the topic still exists in Telegram.
+            # edit_forum_topic returns True both when the name is
+            # updated and when it's unchanged ("not modified").
+            still_alive = await bot.edit_forum_topic(
+                chat_id=chat_id,
+                message_thread_id=existing_thread,
+                name=title,
+            )
+            if still_alive:
+                logger.info(
+                    "issue_topics.already_exists",
+                    issue=issue.number,
+                    thread_id=existing_thread,
+                )
+                results.append(
+                    CreatedIssueTopic(
+                        issue=issue,
+                        thread_id=existing_thread,
+                        already_existed=True,
+                    )
+                )
+                continue
+            # Stale binding — topic was deleted from Telegram.
+            logger.info(
+                "issue_topics.stale_binding",
+                issue=issue.number,
+                thread_id=existing_thread,
+            )
+            await store.delete_thread(chat_id, existing_thread)
+        created = await bot.create_forum_topic(chat_id, title)
+        if created is None:
+            logger.warning(
+                "issue_topics.create_failed",
+                issue=issue.number,
+                chat_id=chat_id,
+            )
+            continue
+
+        thread_id = created.message_thread_id
+        await store.set_context(
+            chat_id,
+            thread_id,
+            context,
+            topic_title=title,
+        )
+
+        # Send a bound-context message into the new topic (same as manual
+        # topic creation) so that Telegram auto-pins it.
+        if transport is not None:
+            bound_label = (
+                f"{display_project} @{branch}" if display_project else f"@{branch}"
+            )
+            bound_text = f"topic bound to `{bound_label}`"
+            rendered_text, entities = prepare_telegram(
+                MarkdownParts(header=bound_text)
+            )
+            await transport.send(
+                channel_id=chat_id,
+                message=RenderedMessage(
+                    text=rendered_text, extra={"entities": entities}
+                ),
+                options=SendOptions(thread_id=thread_id),
+            )
+
+        if project_config is not None:
+            try:
+                wt_path = ensure_worktree(project_config, branch)
+                logger.info(
+                    "issue_topics.worktree_created",
+                    issue=issue.number,
+                    branch=branch,
+                    path=str(wt_path),
+                )
+            except WorktreeError as exc:
+                logger.warning(
+                    "issue_topics.worktree_failed",
+                    issue=issue.number,
+                    branch=branch,
+                    error=str(exc),
+                )
+
+        logger.info(
+            "issue_topics.created",
+            issue=issue.number,
+            thread_id=thread_id,
+            title=title,
+        )
+        results.append(
+            CreatedIssueTopic(
+                issue=issue,
+                thread_id=thread_id,
+                already_existed=False,
+            )
+        )
+        created_count += 1
+        if limit is not None and created_count >= limit:
+            break
+
+    return results

--- a/src/takopi/telegram/loop.py
+++ b/src/takopi/telegram/loop.py
@@ -35,6 +35,7 @@ from .commands.handlers import (
     handle_ctx_command,
     handle_file_command,
     handle_file_put_default,
+    handle_issues_command,
     handle_media_group,
     handle_model_command,
     handle_new_command,
@@ -216,6 +217,16 @@ def _dispatch_builtin_command(
         elif command_id == "topic":
             handler = partial(
                 handle_topic_command,
+                cfg,
+                msg,
+                args_text,
+                topic_store,
+                resolved_scope=resolved_scope,
+                scope_chat_ids=scope_chat_ids,
+            )
+        elif command_id == "issues":
+            handler = partial(
+                handle_issues_command,
                 cfg,
                 msg,
                 args_text,

--- a/src/takopi/telegram/topics.py
+++ b/src/takopi/telegram/topics.py
@@ -28,7 +28,7 @@ __all__ = [
     "_validate_topics_setup",
 ]
 
-_TOPICS_COMMANDS = {"ctx", "new", "topic"}
+_TOPICS_COMMANDS = {"ctx", "new", "topic", "issues"}
 
 
 def _resolve_topics_scope_raw(

--- a/src/takopi/transport_runtime.py
+++ b/src/takopi/transport_runtime.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-from .config import ConfigError, ProjectsConfig
+from .config import ConfigError, ProjectConfig, ProjectsConfig
 from .context import RunContext
 from .directives import (
     ParsedDirectives,
@@ -278,6 +278,9 @@ class TransportRuntime:
     def project_alias_for_key(self, key: str) -> str:
         project = self._projects.projects.get(key)
         return project.alias if project is not None else key
+
+    def project_config_for_key(self, key: str) -> ProjectConfig | None:
+        return self._projects.projects.get(key)
 
     def default_context_for_chat(self, chat_id: int | None) -> RunContext | None:
         project_key = self._projects.project_for_chat(chat_id)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,63 @@
+import pytest
+
+from takopi.github import (
+    GitHubError,
+    GitHubIssue,
+    _parse_owner_repo,
+    issue_branch_name,
+)
+
+
+class TestParseOwnerRepo:
+    def test_https_url(self) -> None:
+        assert _parse_owner_repo("https://github.com/banteg/takopi.git") == (
+            "banteg",
+            "takopi",
+        )
+
+    def test_https_url_no_suffix(self) -> None:
+        assert _parse_owner_repo("https://github.com/banteg/takopi") == (
+            "banteg",
+            "takopi",
+        )
+
+    def test_ssh_url(self) -> None:
+        assert _parse_owner_repo("git@github.com:banteg/takopi.git") == (
+            "banteg",
+            "takopi",
+        )
+
+    def test_ssh_url_no_suffix(self) -> None:
+        assert _parse_owner_repo("git@github.com:banteg/takopi") == (
+            "banteg",
+            "takopi",
+        )
+
+    def test_invalid_url(self) -> None:
+        with pytest.raises(GitHubError, match="cannot parse"):
+            _parse_owner_repo("https://gitlab.com/foo/bar")
+
+    def test_too_few_segments(self) -> None:
+        with pytest.raises(GitHubError, match="cannot parse owner/repo"):
+            _parse_owner_repo("git@github.com:onlyone")
+
+
+class TestIssueBranchName:
+    def test_basic(self) -> None:
+        assert issue_branch_name(42) == "issue/42"
+
+    def test_large_number(self) -> None:
+        assert issue_branch_name(9999) == "issue/9999"
+
+
+class TestGitHubIssue:
+    def test_frozen(self) -> None:
+        issue = GitHubIssue(
+            number=1,
+            title="test",
+            labels=("bug",),
+            state="open",
+            html_url="https://github.com/a/b/issues/1",
+        )
+        with pytest.raises(AttributeError):
+            issue.number = 2  # type: ignore[misc]

--- a/tests/test_issue_topics.py
+++ b/tests/test_issue_topics.py
@@ -1,0 +1,187 @@
+from pathlib import Path
+
+import pytest
+
+from takopi.context import RunContext
+from takopi.github import GitHubIssue
+from takopi.telegram.issue_topics import (
+    CreatedIssueTopic,
+    create_topics_from_issues,
+    issue_topic_title,
+)
+from takopi.telegram.topic_state import TopicStateStore
+from takopi.telegram.api_models import ForumTopic
+from tests.telegram_fakes import FakeBot
+
+
+class _SequentialFakeBot(FakeBot):
+    """FakeBot that returns sequential thread IDs for create_forum_topic."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._next_thread_id = 100
+
+    async def create_forum_topic(self, chat_id: int, name: str) -> ForumTopic | None:
+        tid = self._next_thread_id
+        self._next_thread_id += 1
+        return ForumTopic(message_thread_id=tid)
+
+
+def _issue(number: int, title: str = "fix bug") -> GitHubIssue:
+    return GitHubIssue(
+        number=number,
+        title=title,
+        labels=(),
+        state="open",
+        html_url=f"https://github.com/a/b/issues/{number}",
+    )
+
+
+class TestIssueTopicTitle:
+    def test_with_project(self) -> None:
+        issue = _issue(42, "fix the widget")
+        assert issue_topic_title(issue, "myproj") == "myproj @issue/42"
+
+    def test_without_project(self) -> None:
+        issue = _issue(7, "add tests")
+        assert issue_topic_title(issue) == "@issue/7"
+
+    def test_uses_branch_name(self) -> None:
+        issue = _issue(123, "some long title that should not appear")
+        title = issue_topic_title(issue)
+        assert title == "@issue/123"
+        assert issue.title not in title
+
+
+@pytest.mark.anyio
+async def test_create_topics_basic(tmp_path: Path) -> None:
+    bot = _SequentialFakeBot()
+    store = TopicStateStore(tmp_path / "topics.json")
+    issues = [_issue(1, "first"), _issue(2, "second")]
+
+    results = await create_topics_from_issues(
+        issues=issues,
+        project="alpha",
+        chat_id=100,
+        bot=bot,
+        store=store,
+    )
+
+    assert len(results) == 2
+    assert all(not r.already_existed for r in results)
+    # Verify contexts were stored
+    ctx1 = await store.get_context(100, results[0].thread_id)
+    assert ctx1 == RunContext(project="alpha", branch="issue/1")
+    ctx2 = await store.get_context(100, results[1].thread_id)
+    assert ctx2 == RunContext(project="alpha", branch="issue/2")
+
+
+@pytest.mark.anyio
+async def test_create_topics_skips_existing(tmp_path: Path) -> None:
+    bot = FakeBot()
+    store = TopicStateStore(tmp_path / "topics.json")
+    issues = [_issue(1, "first")]
+
+    # Pre-create a topic for issue/1
+    context = RunContext(project="alpha", branch="issue/1")
+    await store.set_context(100, 999, context, topic_title="alpha #1 first")
+
+    results = await create_topics_from_issues(
+        issues=issues,
+        project="alpha",
+        chat_id=100,
+        bot=bot,
+        store=store,
+    )
+
+    assert len(results) == 1
+    assert results[0].already_existed is True
+    assert results[0].thread_id == 999
+
+
+@pytest.mark.anyio
+async def test_create_topics_with_project_alias(tmp_path: Path) -> None:
+    bot = FakeBot()
+    store = TopicStateStore(tmp_path / "topics.json")
+    issues = [_issue(5, "my issue")]
+
+    results = await create_topics_from_issues(
+        issues=issues,
+        project="alpha",
+        chat_id=100,
+        bot=bot,
+        store=store,
+        project_alias="Alpha",
+    )
+
+    assert len(results) == 1
+    snapshot = await store.get_thread(100, results[0].thread_id)
+    assert snapshot is not None
+    assert "Alpha" in (snapshot.topic_title or "")
+
+
+class _DeletedTopicBot(_SequentialFakeBot):
+    """Bot where edit_forum_topic returns False (topic was deleted)."""
+
+    async def edit_forum_topic(
+        self, chat_id: int, message_thread_id: int, name: str
+    ) -> bool:
+        return False
+
+
+@pytest.mark.anyio
+async def test_auto_cleans_stale_binding(tmp_path: Path) -> None:
+    """When a topic was deleted from Telegram, the stale binding is cleaned up."""
+    bot = _DeletedTopicBot()
+    store = TopicStateStore(tmp_path / "topics.json")
+
+    # Pre-create a stale binding for issue/1
+    context = RunContext(project="alpha", branch="issue/1")
+    await store.set_context(100, 999, context, topic_title="@issue/1")
+
+    results = await create_topics_from_issues(
+        issues=[_issue(1, "first")],
+        project="alpha",
+        chat_id=100,
+        bot=bot,
+        store=store,
+    )
+
+    assert len(results) == 1
+    assert results[0].already_existed is False
+    assert results[0].thread_id != 999
+    ctx = await store.get_context(100, results[0].thread_id)
+    assert ctx == context
+
+
+@pytest.mark.anyio
+async def test_second_sync_skips_already_created(tmp_path: Path) -> None:
+    """Running sync twice with the same issues should not create duplicates."""
+    bot = _SequentialFakeBot()
+    store = TopicStateStore(tmp_path / "topics.json")
+    issues = [_issue(1, "first"), _issue(2, "second")]
+
+    # First sync — creates topics
+    results1 = await create_topics_from_issues(
+        issues=issues,
+        project="alpha",
+        chat_id=100,
+        bot=bot,
+        store=store,
+    )
+    assert len(results1) == 2
+    assert all(not r.already_existed for r in results1)
+
+    # Second sync — should skip all
+    results2 = await create_topics_from_issues(
+        issues=issues,
+        project="alpha",
+        chat_id=100,
+        bot=bot,
+        store=store,
+    )
+    assert len(results2) == 2
+    assert all(r.already_existed for r in results2)
+    # Thread IDs should match the first sync
+    assert results2[0].thread_id == results1[0].thread_id
+    assert results2[1].thread_id == results1[1].thread_id

--- a/tests/test_issues_command.py
+++ b/tests/test_issues_command.py
@@ -1,0 +1,188 @@
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from takopi.config import ProjectConfig, ProjectsConfig
+from takopi.github import GitHubIssue
+from takopi.runners.mock import Return, ScriptRunner
+from takopi.settings import TelegramTopicsSettings
+from takopi.telegram.commands.issues import _handle_issues_command
+from takopi.telegram.topic_state import TopicStateStore
+from takopi.telegram.types import TelegramIncomingMessage
+from takopi.transport_runtime import TransportRuntime
+from tests.telegram_fakes import (
+    DEFAULT_ENGINE_ID,
+    FakeTransport,
+    _make_router,
+    make_cfg,
+)
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        env={"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t", "HOME": str(path)},
+    )
+
+
+def _msg(
+    text: str,
+    *,
+    chat_id: int = 123,
+    message_id: int = 1,
+    thread_id: int | None = None,
+) -> TelegramIncomingMessage:
+    return TelegramIncomingMessage(
+        transport="telegram",
+        chat_id=chat_id,
+        message_id=message_id,
+        text=text,
+        reply_to_message_id=None,
+        reply_to_text=None,
+        sender_id=1,
+        thread_id=thread_id,
+        chat_type="supergroup",
+    )
+
+
+def _runtime(tmp_path: Path) -> TransportRuntime:
+    runner = ScriptRunner([Return(answer="ok")], engine=DEFAULT_ENGINE_ID)
+    projects = ProjectsConfig(
+        projects={
+            "alpha": ProjectConfig(
+                alias="Alpha",
+                path=tmp_path,
+                worktrees_dir=Path(".worktrees"),
+            )
+        },
+        default_project="alpha",
+    )
+    return TransportRuntime(
+        router=_make_router(runner),
+        projects=projects,
+        config_path=tmp_path / "takopi.toml",
+    )
+
+
+def _issues() -> list[GitHubIssue]:
+    return [
+        GitHubIssue(
+            number=1,
+            title="fix bug",
+            labels=("bug",),
+            state="open",
+            html_url="https://github.com/a/b/issues/1",
+        ),
+        GitHubIssue(
+            number=2,
+            title="add feature",
+            labels=(),
+            state="open",
+            html_url="https://github.com/a/b/issues/2",
+        ),
+    ]
+
+
+@pytest.mark.anyio
+async def test_issues_help(tmp_path: Path) -> None:
+    transport = FakeTransport()
+    cfg = replace(
+        make_cfg(transport),
+        topics=TelegramTopicsSettings(enabled=True, scope="all"),
+    )
+    store = TopicStateStore(tmp_path / "topics.json")
+    msg = _msg("/issues")
+
+    await _handle_issues_command(
+        cfg,
+        msg,
+        args_text="",
+        store=store,
+        resolved_scope="all",
+        scope_chat_ids=frozenset({msg.chat_id}),
+    )
+
+    text = transport.send_calls[-1]["message"].text
+    assert "/issues sync" in text
+
+
+@pytest.mark.anyio
+async def test_issues_sync_creates_topics(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    transport = FakeTransport()
+    runtime = _runtime(tmp_path)
+    cfg = replace(
+        make_cfg(transport),
+        runtime=runtime,
+        topics=TelegramTopicsSettings(enabled=True, scope="all"),
+    )
+    store = TopicStateStore(tmp_path / "topics.json")
+    msg = _msg("/issues sync")
+
+    with (
+        patch(
+            "takopi.telegram.commands.issues.parse_github_remote",
+            return_value=("owner", "repo"),
+        ),
+        patch(
+            "takopi.telegram.commands.issues.fetch_issues",
+            new_callable=AsyncMock,
+            return_value=_issues(),
+        ),
+    ):
+        await _handle_issues_command(
+            cfg,
+            msg,
+            args_text="sync",
+            store=store,
+            resolved_scope="all",
+            scope_chat_ids=frozenset({msg.chat_id}),
+        )
+
+    # Should have: "fetching..." message + results message
+    texts = [c["message"].text for c in transport.send_calls]
+    assert any("created 2 topic" in t for t in texts)
+
+
+@pytest.mark.anyio
+async def test_issues_sync_no_issues(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    transport = FakeTransport()
+    runtime = _runtime(tmp_path)
+    cfg = replace(
+        make_cfg(transport),
+        runtime=runtime,
+        topics=TelegramTopicsSettings(enabled=True, scope="all"),
+    )
+    store = TopicStateStore(tmp_path / "topics.json")
+    msg = _msg("/issues sync")
+
+    with (
+        patch(
+            "takopi.telegram.commands.issues.parse_github_remote",
+            return_value=("owner", "repo"),
+        ),
+        patch(
+            "takopi.telegram.commands.issues.fetch_issues",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        await _handle_issues_command(
+            cfg,
+            msg,
+            args_text="sync",
+            store=store,
+            resolved_scope="all",
+            scope_chat_ids=frozenset({msg.chat_id}),
+        )
+
+    texts = [c["message"].text for c in transport.send_calls]
+    assert any("no open issues" in t for t in texts)


### PR DESCRIPTION
Add `/issues sync` command (bot + cli) that fetches open github issues and creates a bound forum topic per issue with eager worktree creation.