### PR TITLE
handle worktree setup script

### DIFF
--- a/docs/how-to/worktrees.md
+++ b/docs/how-to/worktrees.md
@@ -31,6 +31,39 @@ Send a message like:
 /happy-gadgets @feat/memory-box freeze artifacts forever
 ```
 
+## Copy env files after worktree creation
+
+Set `worktree_setup_script` to copy `.env`, agent configs, or other files into the new worktree:
+
+=== "takopi config"
+
+    ```sh
+    takopi config set projects.happy-gadgets.worktree_setup_script "bash scripts/setup-worktree.sh"
+    ```
+
+=== "toml"
+
+    ```toml
+    [projects.happy-gadgets]
+    path = "~/dev/happy-gadgets"
+    worktree_setup_script = "bash .takopi/setup-worktree.sh"
+    ```
+
+The script receives:
+
+- `TAKOPI_WORKTREE_PATH` — absolute path to the new worktree
+- `TAKOPI_PROJECT_PATH` — absolute path to the project root
+- `TAKOPI_BRANCH` — the branch name
+
+Example script (`.takopi/setup-worktree.sh`):
+
+```bash
+cp "$TAKOPI_PROJECT_PATH/.env" "$TAKOPI_WORKTREE_PATH/.env"
+cp -r "$TAKOPI_PROJECT_PATH/.codex" "$TAKOPI_WORKTREE_PATH/.codex"
+```
+
+The script only runs when the worktree is first created. Subsequent messages to the same branch skip it.
+
 ## Ignore `.worktrees/` in git status
 
 If you use the default `.worktrees/` directory inside the repo, add it to a gitignore.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -112,6 +112,7 @@ File size limits (not configurable):
 | `default_engine` | string\|null | `null` | Per-project default engine. |
 | `worktree_base` | string\|null | `null` | Base branch for new worktrees. |
 | `chat_id` | int\|null | `null` | Bind a Telegram chat to this project. |
+| `worktree_setup_script` | string\|null | `null` | Shell command run after a new worktree is created. Env: `TAKOPI_WORKTREE_PATH`, `TAKOPI_PROJECT_PATH`, `TAKOPI_BRANCH`. |
 
 Legacy config note: top-level `bot_token` / `chat_id` are auto-migrated into `[transports.telegram]` on startup.
 

--- a/src/takopi/config.py
+++ b/src/takopi/config.py
@@ -66,6 +66,7 @@ class ProjectConfig:
     default_engine: str | None = None
     worktree_base: str | None = None
     chat_id: int | None = None
+    worktree_setup_script: str | None = None
 
     @property
     def worktrees_root(self) -> Path:

--- a/src/takopi/settings.py
+++ b/src/takopi/settings.py
@@ -139,6 +139,7 @@ class ProjectSettings(BaseModel):
     default_engine: NonEmptyStr | None = None
     worktree_base: NonEmptyStr | None = None
     chat_id: ChatId | None = None
+    worktree_setup_script: NonEmptyStr | None = None
 
 
 class TakopiSettings(BaseSettings):
@@ -281,6 +282,7 @@ class TakopiSettings(BaseSettings):
                 default_engine=default_engine,
                 worktree_base=worktree_base,
                 chat_id=chat_id,
+                worktree_setup_script=entry.worktree_setup_script,
             )
 
         if default_project is not None:

--- a/src/takopi/worktrees.py
+++ b/src/takopi/worktrees.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 
 from .config import ProjectConfig, ProjectsConfig
@@ -57,6 +59,7 @@ def ensure_worktree(project: ProjectConfig, branch: str) -> Path:
         cwd=root,
     ):
         _git_worktree_add(root, worktree_path, branch)
+        _maybe_run_setup_script(project, root, worktree_path, branch)
         return worktree_path
 
     if git_ok(
@@ -70,6 +73,7 @@ def ensure_worktree(project: ProjectConfig, branch: str) -> Path:
             base_ref=f"origin/{branch}",
             create_branch=True,
         )
+        _maybe_run_setup_script(project, root, worktree_path, branch)
         return worktree_path
 
     base = project.worktree_base or resolve_default_base(root)
@@ -83,6 +87,7 @@ def ensure_worktree(project: ProjectConfig, branch: str) -> Path:
         base_ref=base,
         create_branch=True,
     )
+    _maybe_run_setup_script(project, root, worktree_path, branch)
     return worktree_path
 
 
@@ -107,6 +112,35 @@ def _git_worktree_add(
     if result.returncode != 0:
         message = result.stderr.strip() or result.stdout.strip()
         raise WorktreeError(message or "git worktree add failed")
+
+
+def _maybe_run_setup_script(
+    project: ProjectConfig, root: Path, worktree_path: Path, branch: str
+) -> None:
+    if project.worktree_setup_script:
+        _run_setup_script(
+            project.worktree_setup_script,
+            project_path=root,
+            worktree_path=worktree_path,
+            branch=branch,
+        )
+
+
+def _run_setup_script(
+    script: str, *, project_path: Path, worktree_path: Path, branch: str
+) -> None:
+    env = {
+        **os.environ,
+        "TAKOPI_WORKTREE_PATH": str(worktree_path),
+        "TAKOPI_PROJECT_PATH": str(project_path),
+        "TAKOPI_BRANCH": branch,
+    }
+    result = subprocess.run(
+        script, shell=True, cwd=project_path, env=env, text=True, capture_output=True
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip()
+        raise WorktreeError(f"worktree setup script failed: {message or 'no output'}")
 
 
 def _sanitize_branch(branch: str) -> str:

--- a/tests/test_worktrees.py
+++ b/tests/test_worktrees.py
@@ -5,7 +5,7 @@ import pytest
 
 from takopi.config import ProjectConfig, ProjectsConfig
 from takopi.context import RunContext
-from takopi.worktrees import WorktreeError, ensure_worktree, resolve_run_cwd
+from takopi.worktrees import WorktreeError, _run_setup_script, ensure_worktree, resolve_run_cwd
 
 
 def _projects_config(path: Path) -> ProjectsConfig:
@@ -77,6 +77,82 @@ def test_ensure_worktree_creates_from_base(monkeypatch, tmp_path: Path) -> None:
     worktree_path = ensure_worktree(project, "feat/name")
     assert worktree_path == tmp_path / ".worktrees" / "feat" / "name"
     assert calls == [["worktree", "add", "-b", "feat/name", str(worktree_path), "main"]]
+
+
+def test_ensure_worktree_runs_setup_script_on_creation(
+    monkeypatch, tmp_path: Path
+) -> None:
+    script_env: dict = {}
+    project = ProjectConfig(
+        alias="z80",
+        path=tmp_path,
+        worktrees_dir=Path(".worktrees"),
+        worktree_setup_script="echo hello",
+    )
+
+    monkeypatch.setattr("takopi.worktrees.git_ok", lambda *args, **kwargs: False)
+    monkeypatch.setattr("takopi.worktrees.resolve_default_base", lambda *_: "main")
+    monkeypatch.setattr(
+        "takopi.worktrees.git_run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    def _fake_run_setup_script(script, *, project_path, worktree_path, branch):
+        script_env["script"] = script
+        script_env["project_path"] = project_path
+        script_env["worktree_path"] = worktree_path
+        script_env["branch"] = branch
+
+    monkeypatch.setattr("takopi.worktrees._run_setup_script", _fake_run_setup_script)
+
+    worktree_path = ensure_worktree(project, "feat/x")
+    assert script_env["script"] == "echo hello"
+    assert script_env["project_path"] == tmp_path
+    assert script_env["worktree_path"] == worktree_path
+    assert script_env["branch"] == "feat/x"
+
+
+def test_ensure_worktree_skips_setup_script_for_existing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    project = ProjectConfig(
+        alias="z80",
+        path=tmp_path,
+        worktrees_dir=Path(".worktrees"),
+        worktree_setup_script="echo hello",
+    )
+    worktree_path = tmp_path / ".worktrees" / "foo"
+    worktree_path.mkdir(parents=True)
+
+    monkeypatch.setattr("takopi.worktrees.git_is_worktree", lambda _: True)
+
+    script_called = []
+    monkeypatch.setattr(
+        "takopi.worktrees._run_setup_script",
+        lambda *args, **kwargs: script_called.append(True),
+    )
+
+    ensure_worktree(project, "foo")
+    assert script_called == []
+
+
+def test_run_setup_script_raises_on_nonzero(tmp_path: Path) -> None:
+    with pytest.raises(WorktreeError, match="worktree setup script failed"):
+        _run_setup_script(
+            "exit 1",
+            project_path=tmp_path,
+            worktree_path=tmp_path / "wt",
+            branch="feat/x",
+        )
+
+
+def test_run_setup_script_passes_env_vars(tmp_path: Path) -> None:
+    out_file = tmp_path / "env.txt"
+    script = f'echo "$TAKOPI_BRANCH:$TAKOPI_PROJECT_PATH:$TAKOPI_WORKTREE_PATH" > {out_file}'
+    worktree_path = tmp_path / "wt"
+    _run_setup_script(script, project_path=tmp_path, worktree_path=worktree_path, branch="my-branch")
+    content = out_file.read_text().strip()
+    assert content == f"my-branch:{tmp_path}:{worktree_path}"
 
 
 def test_ensure_worktree_rejects_existing_non_worktree(


### PR DESCRIPTION
- add `worktree_setup_script` to project config value
- run script after generating new worktrees, if set
- added 4 tests for this flow