### PR TITLE
fix(windows): resolve codex.cmd via shutil.which

### DIFF
--- a/src/takopi/runners/codex.py
+++ b/src/takopi/runners/codex.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import re
+import shutil
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -445,6 +447,22 @@ class CodexRunState:
     turn_index: int = 0
 
 
+def _resolve_codex_cmd(config_path: Path) -> str:
+    codex_cmd = shutil.which("codex")
+    if codex_cmd:
+        return codex_cmd
+
+    if sys.platform == "win32":
+        codex_cmd = shutil.which("codex.cmd")
+        if codex_cmd:
+            return codex_cmd
+
+    raise ConfigError(
+        f"Could not find the Codex executable on PATH while loading {config_path}. "
+        "Ensure `codex` is installed and available on PATH."
+    )
+
+
 class CodexRunner(ResumeTokenMixin, JsonlSubprocessRunner):
     engine: EngineId = ENGINE
     resume_re = _RESUME_RE
@@ -664,7 +682,7 @@ class CodexRunner(ResumeTokenMixin, JsonlSubprocessRunner):
 
 
 def build_runner(config: EngineConfig, config_path: Path) -> Runner:
-    codex_cmd = "codex"
+    codex_cmd = _resolve_codex_cmd(config_path)
 
     extra_args_value = config.get("extra_args")
     if extra_args_value is None:

--- a/tests/test_codex_runner_helpers.py
+++ b/tests/test_codex_runner_helpers.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import takopi.runners.codex as codex_runner
 from takopi.backends import EngineConfig
 from takopi.config import ConfigError
 from takopi.events import EventFactory
@@ -251,3 +252,26 @@ def test_codex_build_runner_configs(tmp_path: Path) -> None:
 
     with pytest.raises(ConfigError):
         build_runner({"profile": 123}, tmp_path)
+
+
+def test_codex_build_runner_resolves_windows_executable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    codex_calls: list[str] = []
+
+    def fake_which(name: str) -> str | None:
+        codex_calls.append(name)
+        if name == "codex":
+            return None
+        if name == "codex.cmd":
+            return r"C:\Tools\codex.cmd"
+        return None
+
+    monkeypatch.setattr(codex_runner.shutil, "which", fake_which, raising=False)
+    monkeypatch.setattr(codex_runner.sys, "platform", "win32")
+
+    runner = build_runner({}, Path("takopi.toml"))
+
+    assert isinstance(runner, CodexRunner)
+    assert codex_calls == ["codex", "codex.cmd"]
+    assert runner.codex_cmd == r"C:\Tools\codex.cmd"


### PR DESCRIPTION
## Summary

Fix Windows `takopi codex` runner startup by resolving the Codex executable from `PATH` instead of hardcoding `"codex"`.

## Problem

On Windows, Codex is commonly installed as `codex.cmd` via npm. PowerShell resolves that fine, but Python subprocess invocation does not automatically pick it up when Takopi hardcodes `"codex"` in `src/takopi/runners/codex.py`.

That leads to:

```text
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

The repo already handled the same Windows CLI resolution problem for Claude in:

- issue #58
- PR #124

`claude.py` now resolves the executable via `shutil.which(...)`, but `codex.py` still uses a hardcoded `"codex"`.

## Changes

- resolve `codex` with `shutil.which("codex")`
- on Windows, also try `shutil.which("codex.cmd")`
- raise a clear `ConfigError` if no Codex executable is found on `PATH`

## Why this approach

This is a small runner-local fix that matches the existing precedent in `claude.py` and avoids relying on shell-specific command resolution behavior.

If you'd prefer to solve this centrally through the broader Windows subprocess handling in #204, I am happy to rework or close this PR.
