### PR TITLE
fix(telegram): linkify bare URLs across more formats

### DIFF
--- a/src/takopi/telegram/render.py
+++ b/src/takopi/telegram/render.py
@@ -17,6 +17,18 @@ _BULLET_RE = re.compile(r"(?m)^(\s*)•")
 _FENCE_RE = re.compile(r"^(?P<indent>[ \t]*)(?P<fence>[`~]{3,})(?P<info>.*)$")
 _ORDERED_ITEM_RE = re.compile(r"^(?P<indent>[ \t]{0,3})(?P<marker>\d+[.)])\s+")
 _UNORDERED_ITEM_RE = re.compile(r"^(?P<indent>[ \t]{0,3})[-+*]\s+")
+_BARE_URL_RE = re.compile(
+    r"("
+    r"(?:[a-z][a-z0-9+.\-]*:(?://)?[^\s<>]+)"
+    r"|"
+    r"(?:www\.[^\s<>]*[^\s<>.,;:!?\)\]\"'])"
+    r"|"
+    r"(?:[a-z0-9-]+\.)+[a-z]{2,}(?:/[^\s<>]*[^\s<>.,;:!?\)\]\"'])?"
+    r")",
+    re.IGNORECASE,
+)
+_INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+_INLINE_LINK_RE = re.compile(r"\[[^\]\n]*\]\([^)]+\)")
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,8 +85,76 @@ def _normalize_nested_list_markers(md: str) -> str:
     return "".join(lines)
 
 
+def _collect_fence_ranges(md: str) -> list[tuple[int, int]]:
+    ranges: list[tuple[int, int]] = []
+    state: _FenceState | None = None
+    offset = 0
+
+    for raw_line in md.splitlines(keepends=True):
+        line, _ = _split_line_ending(raw_line)
+        line_end = offset + len(raw_line)
+
+        if state is not None:
+            ranges.append((offset, line_end))
+            state = _update_fence_state(line, state)
+            offset = line_end
+            continue
+
+        next_state = _update_fence_state(line, None)
+        if next_state is not None:
+            ranges.append((offset, line_end))
+            state = next_state
+
+        offset = line_end
+
+    return ranges
+
+
+def _linkify_bare_urls(md: str) -> str:
+    if not md:
+        return md
+
+    skip_ranges = _collect_fence_ranges(md)
+    skip_ranges.extend((m.start(), m.end()) for m in _INLINE_CODE_RE.finditer(md))
+    skip_ranges.extend((m.start(), m.end()) for m in _INLINE_LINK_RE.finditer(md))
+
+    def _in_skip(start: int, end: int) -> bool:
+        return any(
+            skip_start < end and start < skip_end
+            for skip_start, skip_end in skip_ranges
+        )
+
+    def _already_linked(start: int) -> bool:
+        before = md[:start].rstrip()
+        if before.endswith("](") or before.endswith("<"):
+            return True
+        link_open_idx = before.rfind("](")
+        if link_open_idx == -1:
+            return False
+        return before.rfind(")") < link_open_idx
+
+    parts: list[str] = []
+    last = 0
+    for match in _BARE_URL_RE.finditer(md):
+        start = match.start(1)
+        end = match.end(1)
+        if _in_skip(start, end) or _already_linked(start):
+            continue
+        parts.append(md[last:start])
+        url = match.group(1)
+        if url.startswith(("http://", "https://")):
+            parts.append(f"<{url}>")
+        else:
+            parts.append(f"[{url}]({url})")
+        last = end
+
+    parts.append(md[last:])
+    return "".join(parts)
+
+
 def render_markdown(md: str) -> tuple[str, list[dict[str, Any]]]:
-    html = _MD_RENDERER.render(_normalize_nested_list_markers(md or ""))
+    normalized = _normalize_nested_list_markers(md or "")
+    html = _MD_RENDERER.render(_linkify_bare_urls(normalized))
     rendered = transform_html(html)
 
     text = _BULLET_RE.sub(r"\1-", rendered.text)
@@ -99,6 +179,13 @@ def _is_supported_text_link_url(url: str) -> bool:
     parsed = urlparse(url)
     if parsed.scheme in {"http", "https"} and bool(parsed.netloc):
         return True
+    if not parsed.scheme and not parsed.netloc:
+        candidate = parsed.path or ""
+        if candidate.startswith("/"):
+            return False
+        host = candidate.split("/", 1)[0]
+        if host.startswith("www.") or "." in host:
+            return True
     return parsed.scheme == "tg" and (bool(parsed.netloc) or bool(parsed.path))
 
 

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,6 +1,111 @@
 import re
 
-from takopi.telegram.render import render_markdown, split_markdown_body
+import pytest
+
+from takopi.telegram.render import _BARE_URL_RE, render_markdown, split_markdown_body
+
+URL_RECOGNITION_CASES = [
+    "http://example.com",
+    "https://example.com",
+    "http://www.example.com",
+    "https://www.example.com/",
+    "https://example.com/path",
+    "https://example.com/path/",
+    "https://example.com/path/to/resource",
+    "https://example.com/path/to/resource/",
+    "https://example.com/path/to/resource.html",
+    "https://example.com/path/to/resource.html?query=1",
+    "https://example.com/path/to/resource.html?query=1&foo=bar",
+    "https://example.com/path/to/resource?query=слово",
+    "https://example.com/path/to/resource?query=слово#anchor",
+    "https://example.com/#anchor",
+    "https://example.com/path#section-1",
+    "https://sub.example.com",
+    "https://deep.sub.domain.example.com",
+    "http://localhost",
+    "http://localhost:3000",
+    "http://127.0.0.1",
+    "http://127.0.0.1:8080/health",
+    "https://[2001:db8::1]/",
+    "https://[2001:db8::1]:8443/status",
+    "ftp://ftp.example.com/pub/file.txt",
+    "ftps://secure.example.com/downloads",
+    "sftp://user@example.com/home/user/file",
+    "mailto:user@example.com",
+    "mailto:user.name+tag@example.co.uk",
+    "tel:+1-202-555-0100",
+    "tel:+7-999-123-45-67",
+    "ssh://user@example.com",
+    "ssh://user@example.com:2222/home/user",
+    "file:///etc/hosts",
+    "file:///C:/Windows/System32/drivers/etc/hosts",
+    "data:text/plain,Hello%20World",
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
+    "https://example.com?only=query",
+    "https://example.com?param1=value1&param2=&param3",
+    "https://example.com?encoded=%D1%82%D0%B5%D1%81%D1%82",
+    "https://example.com?arr[]=1&arr[]=2&arr[]=3",
+    "https://example.com/path%20with%20spaces",
+    "https://example.com/путь/с/юникодом",
+    "https://пример.рф",
+    "https://домен.рф/путь?параметр=значение",
+    "http://example.com:80",
+    "https://example.com:443",
+    "https://example.com:8443/custom-port",
+    "http://blog.example.com/article?id=123",
+    "https://shop.example.com/products/12345?color=red&size=m",
+    "https://api.example.com/v1/users/42",
+    "https://api.example.com/v1/users/42?include=posts,comments",
+    "https://cdn.example.com/assets/app.js?v=1.2.3",
+    "https://example.com/path?redirect=https%3A%2F%2Fother.com%2Fpage",
+    "https://example.com/path;param1;param2?query=1",
+    "https://example.com/path/to/resource.json",
+    "https://example.com/path/to/resource.xml",
+    "https://example.com/path/to/resource.jpeg",
+    "https://example.com/path/to/resource.tar.gz",
+    "https://example.com/.well-known/security.txt",
+    "https://example.com/.gitignore",
+    "https://user:pass@example.com",
+    "https://user:pass@example.com:8443/private",
+    "http://user@example.com",
+    "http://user:@example.com",
+    "https://example.com/path?empty=",
+    "https://example.com/path?flag",
+    "https://example.com/#",
+    "https://example.com/#/spa/route",
+    "https://example.com/path/?trailing=slash",
+    "https://example.com/a/b/../c/d",
+    "https://example.com/a/%2E%2E/c/d",
+    "https://example.com/a/b/c?x=1#y=2",
+    "https://example.com:12345/custom/port/path",
+    "https://sub-domain.example.co.uk/path",
+    "https://sub_domain.example.com/path_with_underscores",
+    "https://example.com/path-with-dashes",
+    "https://example.com/123/456/789",
+    "https://example.com/2024/12/31/happy-new-year",
+    "https://example.com/?q=URL+parsing+test",
+    "https://example.com/?q=100%25+coverage",
+    "https://example.com/?q=%E2%9C%93",
+    "https://例子.测试/路径?查询=值",
+    "https://example.com/(test)/[brackets]",
+    "https://example.com/path?special=!@#$%^&*()",
+    "https://example.com/path?json=%7B%22a%22%3A1%2C%22b%22%3A2%7D",
+    'https://example.com/path,\'"quotes"',
+    "https://example.com/path?with=comma,semicolon;colon:",
+    "https://example.com/path?multi=line%0Avalue",
+    "https://example.com/path?tab=one%09two",
+    "https://user.name+tag@example.com/profile",
+    "https://example.travel",
+    "https://example.museum",
+    "https://example.xyz",
+    "https://example.dev",
+    "https://example.ai",
+    "https://sub.пример.рф/каталог/товар?id=10&sort=asc",
+    "https://example.com:65535/max-port",
+    "http://example.com:1/min-port",
+    "https://example.com/?emoji=%F0%9F%98%80",
+    "https://example.com/very/long/path/with/many/segments/and/query?one=1&two=2&three=3#long-fragment-section-10",
+]
 
 
 def test_render_markdown_basic_entities() -> None:
@@ -11,6 +116,12 @@ def test_render_markdown_basic_entities() -> None:
         {"type": "bold", "offset": 0, "length": 4},
         {"type": "code", "offset": 9, "length": 4},
     ]
+
+
+@pytest.mark.parametrize("url", URL_RECOGNITION_CASES)
+def test_bare_url_regex_recognizes_url_corpus(url: str) -> None:
+    match = _BARE_URL_RE.fullmatch(url)
+    assert match is not None
 
 
 def test_render_markdown_code_fence_language_is_string() -> None:
@@ -33,6 +144,54 @@ def test_render_markdown_keeps_https_text_links() -> None:
     _, entities = render_markdown("[docs](https://example.com/path)")
 
     assert any(
+        e.get("type") == "text_link" and e.get("url") == "https://example.com/path"
+        for e in entities
+    )
+
+
+def test_render_markdown_linkifies_bare_https_urls() -> None:
+    text, entities = render_markdown("See https://example.com/path for docs.")
+
+    assert "https://example.com/path" in text
+    assert any(
+        e.get("type") == "text_link" and e.get("url") == "https://example.com/path"
+        for e in entities
+    )
+
+
+def test_render_markdown_linkifies_bare_www_urls() -> None:
+    text, entities = render_markdown("See www.example.com/path for docs")
+
+    assert "www.example.com/path" in text
+    assert any(
+        e.get("type") == "text_link" and e.get("url") == "www.example.com/path"
+        for e in entities
+    )
+
+
+def test_render_markdown_linkifies_bare_urls() -> None:
+    text, entities = render_markdown("See example.com/path for docs.")
+
+    assert "example.com/path" in text
+    assert any(
+        e.get("type") == "text_link" and e.get("url") == "example.com/path"
+        for e in entities
+    )
+
+
+def test_render_markdown_does_not_linkify_urls_inside_inline_code() -> None:
+    _, entities = render_markdown("Use `https://example.com/path` literally.")
+
+    assert not any(
+        e.get("type") == "text_link" and e.get("url") == "https://example.com/path"
+        for e in entities
+    )
+
+
+def test_render_markdown_does_not_linkify_urls_inside_fenced_code() -> None:
+    _, entities = render_markdown("```txt\nhttps://example.com/path\n```")
+
+    assert not any(
         e.get("type") == "text_link" and e.get("url") == "https://example.com/path"
         for e in entities
     )


### PR DESCRIPTION
## Summary
- expand Telegram bare URL detection to include scheme URLs, `www.` hosts, and bare domains
- preserve safe skip zones (inline code, fenced code, and existing markdown links) to avoid double-linking
- add a parametrized URL-recognition corpus (100 cases) plus rendering regression tests for bare `www` and bare domain links

## Test Plan
- [x] `python -m black src/takopi/telegram/render.py tests/test_rendering.py`
- [x] `python -m pytest -q --no-cov tests/test_rendering.py`
- [x] `python -m pytest -q --no-cov tests/test_telegram*.py`
