### PR TITLE
fix(runners, paths): resolve Windows CLI paths and normalize relativized separators

### DIFF
--- a/src/takopi/runners/codex.py
+++ b/src/takopi/runners/codex.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -664,7 +665,7 @@ class CodexRunner(ResumeTokenMixin, JsonlSubprocessRunner):
 
 
 def build_runner(config: EngineConfig, config_path: Path) -> Runner:
-    codex_cmd = "codex"
+    codex_cmd = shutil.which("codex") or "codex"
 
     extra_args_value = config.get("extra_args")
     if extra_args_value is None:

--- a/src/takopi/runners/codex.py
+++ b/src/takopi/runners/codex.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import re
+import shutil
 import subprocess
 import uuid
 from collections.abc import AsyncIterator
@@ -1360,7 +1361,7 @@ class AppServerCodexRunner(ResumeTokenMixin, BaseRunner):
 
 
 def build_runner(config: EngineConfig, config_path: Path) -> Runner:
-    codex_cmd = "codex"
+    codex_cmd = shutil.which("codex") or "codex"
 
     mode_value = config.get("mode", "app_server")
     if mode_value not in {"app_server", "exec"}:

--- a/src/takopi/runners/opencode.py
+++ b/src/takopi/runners/opencode.py
@@ -14,6 +14,7 @@ Session IDs use the format: ses_XXXX (e.g., ses_494719016ffe85dkDMj0FPRbHK)
 from __future__ import annotations
 
 import re
+import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -478,7 +479,7 @@ class OpenCodeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
 
 def build_runner(config: EngineConfig, config_path: Path) -> Runner:
     """Build an OpenCodeRunner from configuration."""
-    opencode_cmd = "opencode"
+    opencode_cmd = shutil.which("opencode") or "opencode"
 
     model = config.get("model")
     if model is not None and not isinstance(model, str):

--- a/src/takopi/runners/opencode.py
+++ b/src/takopi/runners/opencode.py
@@ -14,6 +14,7 @@ Session IDs use the format: ses_XXXX (e.g., ses_494719016ffe85dkDMj0FPRbHK)
 from __future__ import annotations
 
 import re
+import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -481,7 +482,7 @@ class OpenCodeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
 
 def build_runner(config: EngineConfig, config_path: Path) -> Runner:
     """Build an OpenCodeRunner from configuration."""
-    opencode_cmd = "opencode"
+    opencode_cmd = shutil.which("opencode") or "opencode"
 
     model = config.get("model")
     if model is not None and not isinstance(model, str):

--- a/src/takopi/runners/pi.py
+++ b/src/takopi/runners/pi.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import datetime, UTC
@@ -282,7 +283,9 @@ class PiRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         extra_args: list[str],
         model: str | None,
         provider: str | None,
+        pi_cmd: str = "pi",
     ) -> None:
+        self.pi_cmd = pi_cmd
         self.extra_args = extra_args
         self.model = model
         self.provider = provider
@@ -314,7 +317,7 @@ class PiRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         return ResumeToken(engine=self.engine, value=found)
 
     def command(self) -> str:
-        return "pi"
+        return self.pi_cmd
 
     def build_args(
         self,
@@ -488,6 +491,7 @@ def _default_session_dir(cwd: PurePath) -> Path:
 
 
 def build_runner(config: EngineConfig, config_path: Path) -> Runner:
+    pi_cmd = shutil.which("pi") or "pi"
     extra_args_value = config.get("extra_args")
     if extra_args_value is None:
         extra_args = []
@@ -512,6 +516,7 @@ def build_runner(config: EngineConfig, config_path: Path) -> Runner:
         extra_args=extra_args,
         model=model,
         provider=provider,
+        pi_cmd=pi_cmd,
     )
 
 

--- a/src/takopi/runners/pi.py
+++ b/src/takopi/runners/pi.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import datetime, UTC
@@ -282,7 +283,9 @@ class PiRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         extra_args: list[str],
         model: str | None,
         provider: str | None,
+        pi_cmd: str = "pi",
     ) -> None:
+        self.pi_cmd = pi_cmd
         self.extra_args = extra_args
         self.model = model
         self.provider = provider
@@ -314,7 +317,7 @@ class PiRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         return ResumeToken(engine=self.engine, value=found)
 
     def command(self) -> str:
-        return "pi"
+        return self.pi_cmd
 
     def build_args(
         self,
@@ -490,6 +493,7 @@ def _default_session_dir(cwd: PurePath) -> Path:
 
 
 def build_runner(config: EngineConfig, config_path: Path) -> Runner:
+    pi_cmd = shutil.which("pi") or "pi"
     extra_args_value = config.get("extra_args")
     if extra_args_value is None:
         extra_args = []
@@ -514,6 +518,7 @@ def build_runner(config: EngineConfig, config_path: Path) -> Runner:
         extra_args=extra_args,
         model=model,
         provider=provider,
+        pi_cmd=pi_cmd,
     )
 
 

--- a/src/takopi/utils/paths.py
+++ b/src/takopi/utils/paths.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from contextvars import ContextVar, Token
 from pathlib import Path
 
@@ -20,6 +19,21 @@ def reset_run_base_dir(token: Token[Path | None]) -> None:
     _run_base_dir.reset(token)
 
 
+def _path_variants(base: str) -> tuple[str, ...]:
+    normalized = base.rstrip("/\\")
+    if not normalized:
+        return ()
+    variants: list[str] = []
+    for candidate in (
+        normalized,
+        normalized.replace("\\", "/"),
+        normalized.replace("/", "\\"),
+    ):
+        if candidate and candidate not in variants:
+            variants.append(candidate)
+    return tuple(variants)
+
+
 def relativize_path(value: str, *, base_dir: Path | None = None) -> str:
     if not value:
         return value
@@ -29,13 +43,14 @@ def relativize_path(value: str, *, base_dir: Path | None = None) -> str:
     base_str = str(base)
     if not base_str:
         return value
-    if value == base_str:
-        return "."
-    for sep in (os.sep, "/"):
-        prefix = base_str if base_str.endswith(sep) else f"{base_str}{sep}"
-        if value.startswith(prefix):
-            suffix = value[len(prefix) :]
-            return suffix or "."
+    for base_variant in _path_variants(base_str):
+        if value == base_variant:
+            return "."
+        for sep in ("/", "\\"):
+            prefix = f"{base_variant}{sep}"
+            if value.startswith(prefix):
+                suffix = value[len(prefix) :]
+                return (suffix or ".").replace("\\", "/")
     return value
 
 
@@ -43,5 +58,9 @@ def relativize_command(value: str, *, base_dir: Path | None = None) -> str:
     base = get_run_base_dir() if base_dir is None else base_dir
     if base is None:
         base = Path.cwd()
-    base_with_sep = f"{base}{os.sep}"
-    return value.replace(base_with_sep, "")
+    base_str = str(base)
+    out = value
+    for base_variant in _path_variants(base_str):
+        for sep in ("/", "\\"):
+            out = out.replace(f"{base_variant}{sep}", "")
+    return out

--- a/tests/test_codex_runner_helpers.py
+++ b/tests/test_codex_runner_helpers.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import takopi.runners.codex as codex_runner
 from takopi.backends import EngineConfig
 from takopi.config import ConfigError
 from takopi.events import EventFactory
@@ -251,3 +252,19 @@ def test_codex_build_runner_configs(tmp_path: Path) -> None:
 
     with pytest.raises(ConfigError):
         build_runner({"profile": 123}, tmp_path)
+
+
+def test_codex_build_runner_uses_shutil_which(monkeypatch) -> None:
+    expected = r"C:\Tools\codex.cmd"
+    called: dict[str, str] = {}
+
+    def fake_which(name: str) -> str | None:
+        called["name"] = name
+        return expected
+
+    monkeypatch.setattr(codex_runner.shutil, "which", fake_which)
+    runner = build_runner({}, Path("takopi.toml"))
+
+    assert called["name"] == "codex"
+    assert isinstance(runner, CodexRunner)
+    assert runner.codex_cmd == expected

--- a/tests/test_codex_runner_helpers.py
+++ b/tests/test_codex_runner_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sys
 
 import anyio
 import pytest
@@ -264,7 +265,7 @@ async def test_app_server_client_fails_waiters_on_clean_eof(tmp_path: Path) -> N
         encoding="utf-8",
     )
     codex_path.chmod(0o755)
-    client = _AppServerClient(codex_cmd=str(codex_path), extra_args=[])
+    client = _AppServerClient(codex_cmd=sys.executable, extra_args=[str(codex_path)])
 
     with anyio.fail_after(2), pytest.raises(RuntimeError, match="closed stdout"):
         await client.start()
@@ -322,7 +323,10 @@ async def test_app_server_runner_raises_on_turn_stream_eof(
         encoding="utf-8",
     )
     codex_path.chmod(0o755)
-    runner = AppServerCodexRunner(codex_cmd=str(codex_path), extra_args=[])
+    runner = AppServerCodexRunner(
+        codex_cmd=sys.executable,
+        extra_args=[str(codex_path)],
+    )
 
     stream = runner.run("hello", None)
     with anyio.fail_after(2):
@@ -375,7 +379,10 @@ async def test_app_server_codex_runner_translates_turn_notifications(
         encoding="utf-8",
     )
     codex_path.chmod(0o755)
-    runner = AppServerCodexRunner(codex_cmd=str(codex_path), extra_args=[])
+    runner = AppServerCodexRunner(
+        codex_cmd=sys.executable,
+        extra_args=[str(codex_path)],
+    )
 
     with anyio.fail_after(2):
         events = [event async for event in runner.run("hello", None)]
@@ -463,5 +470,5 @@ def test_codex_build_runner_uses_shutil_which(monkeypatch) -> None:
     runner = build_runner({}, Path("takopi.toml"))
 
     assert called["name"] == "codex"
-    assert isinstance(runner, CodexRunner)
+    assert isinstance(runner, AppServerCodexRunner)
     assert runner.codex_cmd == expected

--- a/tests/test_codex_runner_helpers.py
+++ b/tests/test_codex_runner_helpers.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import anyio
 import pytest
 
+import takopi.runners.codex as codex_runner
 from takopi.backends import EngineConfig
 from takopi.config import ConfigError
 from takopi.events import EventFactory
@@ -448,3 +449,19 @@ def test_codex_build_runner_configs(tmp_path: Path) -> None:
 
     with pytest.raises(ConfigError):
         build_runner({"profile": 123}, tmp_path)
+
+
+def test_codex_build_runner_uses_shutil_which(monkeypatch) -> None:
+    expected = r"C:\Tools\codex.cmd"
+    called: dict[str, str] = {}
+
+    def fake_which(name: str) -> str | None:
+        called["name"] = name
+        return expected
+
+    monkeypatch.setattr(codex_runner.shutil, "which", fake_which)
+    runner = build_runner({}, Path("takopi.toml"))
+
+    assert called["name"] == "codex"
+    assert isinstance(runner, CodexRunner)
+    assert runner.codex_cmd == expected

--- a/tests/test_opencode_runner.py
+++ b/tests/test_opencode_runner.py
@@ -4,11 +4,13 @@ from pathlib import Path
 import anyio
 import pytest
 
+import takopi.runners.opencode as opencode_runner
 from takopi.model import ActionEvent, CompletedEvent, ResumeToken, StartedEvent
 from takopi.runners.opencode import (
     OpenCodeRunner,
     OpenCodeStreamState,
     ENGINE,
+    build_runner,
     translate_opencode_event,
 )
 from takopi.schemas import opencode as opencode_schema
@@ -366,3 +368,19 @@ async def test_run_serializes_same_session() -> None:
         await anyio.sleep(0)
         gate.set()
     assert max_in_flight == 1
+
+
+def test_opencode_build_runner_uses_shutil_which(monkeypatch) -> None:
+    expected = r"C:\Tools\opencode.cmd"
+    called: dict[str, str] = {}
+
+    def fake_which(name: str) -> str | None:
+        called["name"] = name
+        return expected
+
+    monkeypatch.setattr(opencode_runner.shutil, "which", fake_which)
+    runner = build_runner({}, Path("takopi.toml"))
+
+    assert called["name"] == "opencode"
+    assert isinstance(runner, OpenCodeRunner)
+    assert runner.opencode_cmd == expected

--- a/tests/test_opencode_runner.py
+++ b/tests/test_opencode_runner.py
@@ -4,11 +4,13 @@ from pathlib import Path
 import anyio
 import pytest
 
+import takopi.runners.opencode as opencode_runner
 from takopi.model import ActionEvent, CompletedEvent, ResumeToken, StartedEvent
 from takopi.runners.opencode import (
     OpenCodeRunner,
     OpenCodeStreamState,
     ENGINE,
+    build_runner,
     translate_opencode_event,
 )
 from takopi.schemas import opencode as opencode_schema
@@ -380,3 +382,19 @@ async def test_run_serializes_same_session() -> None:
         await anyio.sleep(0)
         gate.set()
     assert max_in_flight == 1
+
+
+def test_opencode_build_runner_uses_shutil_which(monkeypatch) -> None:
+    expected = r"C:\Tools\opencode.cmd"
+    called: dict[str, str] = {}
+
+    def fake_which(name: str) -> str | None:
+        called["name"] = name
+        return expected
+
+    monkeypatch.setattr(opencode_runner.shutil, "which", fake_which)
+    runner = build_runner({}, Path("takopi.toml"))
+
+    assert called["name"] == "opencode"
+    assert isinstance(runner, OpenCodeRunner)
+    assert runner.opencode_cmd == expected

--- a/tests/test_pi_runner.py
+++ b/tests/test_pi_runner.py
@@ -4,12 +4,14 @@ from unittest.mock import patch
 import anyio
 import pytest
 
+import takopi.runners.pi as pi_runner
 from takopi.model import ActionEvent, CompletedEvent, ResumeToken, StartedEvent
 from takopi.runners.pi import (
     ENGINE,
     PiRunner,
     PiStreamState,
     _default_session_dir,
+    build_runner,
     translate_pi_event,
 )
 from takopi.schemas import pi as pi_schema
@@ -228,3 +230,19 @@ def test_session_path_sanitizes_windows_separators() -> None:
     name = session_dir.name
     assert "\\" not in name
     assert ":" not in name
+
+
+def test_pi_build_runner_uses_shutil_which(monkeypatch) -> None:
+    expected = r"C:\Tools\pi.cmd"
+    called: dict[str, str] = {}
+
+    def fake_which(name: str) -> str | None:
+        called["name"] = name
+        return expected
+
+    monkeypatch.setattr(pi_runner.shutil, "which", fake_which)
+    runner = build_runner({}, Path("takopi.toml"))
+
+    assert called["name"] == "pi"
+    assert isinstance(runner, PiRunner)
+    assert runner.pi_cmd == expected


### PR DESCRIPTION
# Relates to

- Follow-up to #58

# Risks

Medium.
- Runner command resolution now prefers executable discovery via `shutil.which(...)`; behavior depends on PATH order on Windows.
- Path relativization now strips base prefixes across both slash styles and normalizes output to `/`, which can change rendered/logged path strings.

# Background

## What does this PR do?

- Resolves `codex`, `opencode`, and `pi` command paths in each `build_runner` using `shutil.which(...)` with fallback to the original command string.
- Adds `pi_cmd` wiring to `PiRunner` so command execution uses the discovered executable path.
- Normalizes relativized path and command output across mixed `/` and `\\` separators.
- Adds focused unit tests covering command-resolution behavior for `codex`, `opencode`, and `pi` runners.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)

## Why?

Windows environments can resolve CLI commands differently than POSIX shells. Explicit executable discovery and slash-style normalization reduce cross-platform path bugs and stabilize output/tests.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

- `src/takopi/runners/codex.py` (`build_runner` command resolution)
- `src/takopi/runners/opencode.py` (`build_runner` command resolution)
- `src/takopi/runners/pi.py` (`pi_cmd` plumbing + `build_runner` resolution)
- `src/takopi/utils/paths.py` (`relativize_path`/`relativize_command` slash normalization)
- `tests/test_codex_runner_helpers.py`
- `tests/test_opencode_runner.py`
- `tests/test_pi_runner.py`

## Detailed testing steps

Automated tests added:
- `test_codex_build_runner_uses_shutil_which`
- `test_opencode_build_runner_uses_shutil_which`
- `test_pi_build_runner_uses_shutil_which`

Suggested command:

```bash
pytest -q tests/test_codex_runner_helpers.py tests/test_opencode_runner.py tests/test_pi_runner.py
```
