### PR TITLE
feat: Claude interactive permission handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "takopi"
 authors = [{name = "banteg"}]
-version = "0.22.3"
+version = "0.22.4"
 description = "Telegram bridge for Codex, Claude Code, and other agent CLIs."
 readme = "readme.md"
 license = { file = "LICENSE" }

--- a/src/takopi/model.py
+++ b/src/takopi/model.py
@@ -75,3 +75,18 @@ class CompletedEvent:
 
 
 type TakopiEvent = StartedEvent | ActionEvent | CompletedEvent
+
+
+@dataclass(frozen=True, slots=True)
+class InteractiveOption:
+    id: str
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
+class InteractiveRequest:
+    request_id: str
+    kind: str
+    title: str
+    description: str | None
+    options: list[InteractiveOption]

--- a/src/takopi/runner.py
+++ b/src/takopi/runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 import subprocess
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Protocol, cast
 from weakref import WeakValueDictionary
@@ -182,6 +182,9 @@ class JsonlSubprocessRunner(BaseRunner):
         state: Any,
     ) -> None:
         return None
+
+    def keep_stdin_open(self) -> bool:
+        return False
 
     def pipes_error_message(self) -> str:
         return f"{self.tag()} failed to open subprocess pipes"
@@ -360,7 +363,8 @@ class JsonlSubprocessRunner(BaseRunner):
         if payload is not None:
             assert proc.stdin is not None
             await proc.stdin.send(payload)
-            await proc.stdin.aclose()
+            if not self.keep_stdin_open():
+                await proc.stdin.aclose()
             logger.info(
                 "subprocess.stdin.send",
                 pid=proc.pid,
@@ -368,7 +372,20 @@ class JsonlSubprocessRunner(BaseRunner):
                 bytes=len(payload),
             )
         elif proc.stdin is not None:
-            await proc.stdin.aclose()
+            if not self.keep_stdin_open():
+                await proc.stdin.aclose()
+
+    async def _after_send_payload(self, proc: Any, *, state: Any) -> None:
+        pass
+
+    async def handle_interactive(
+        self,
+        request: Any,
+        *,
+        state: Any,
+        send_to_stdin: Callable[[bytes], Awaitable[None]],
+    ) -> None:
+        pass
 
     def _decode_jsonl_events(
         self,
@@ -635,6 +652,7 @@ class JsonlSubprocessRunner(BaseRunner):
             )
 
             await self._send_payload(proc, payload, logger=logger, resume=resume)
+            await self._after_send_payload(proc, state=state)
 
             rc: int | None = None
             stream = JsonlStreamState(expected_session=resume)

--- a/src/takopi/runner_bridge.py
+++ b/src/takopi/runner_bridge.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from typing import Any
 
 import anyio
 
@@ -10,6 +11,7 @@ from .context import RunContext
 from .logging import bind_run_context, get_logger
 from .model import CompletedEvent, ResumeToken, StartedEvent, TakopiEvent
 from .presenter import Presenter
+from .runners.run_options import get_run_options
 from .markdown import render_event_cli
 from .runner import Runner
 from .progress import ProgressTracker
@@ -94,6 +96,7 @@ class RunningTask:
     cancel_requested: anyio.Event = field(default_factory=anyio.Event)
     done: anyio.Event = field(default_factory=anyio.Event)
     context: RunContext | None = None
+    interactive_handler: Any | None = None
 
 
 RunningTasks = dict[MessageRef, RunningTask]
@@ -446,6 +449,12 @@ async def handle_message(
     if running_tasks is not None and progress_ref is not None:
         running_task = RunningTask(context=context)
         running_tasks[progress_ref] = running_task
+        run_opts = get_run_options()
+        if run_opts is not None and run_opts.interactive_handler is not None:
+            ih = run_opts.interactive_handler
+            if hasattr(ih, "_on_running_task_created"):
+                ih._on_running_task_created(running_task, progress_ref)
+            running_task.interactive_handler = ih
 
     cancel_exc_type = anyio.get_cancelled_exc_class()
     edits_scope = anyio.CancelScope()

--- a/src/takopi/runners/claude.py
+++ b/src/takopi/runners/claude.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -12,8 +13,8 @@ import msgspec
 from ..backends import EngineBackend, EngineConfig
 from ..events import EventFactory
 from ..logging import get_logger
-from ..model import Action, ActionKind, EngineId, ResumeToken, TakopiEvent
-from ..runner import JsonlSubprocessRunner, ResumeTokenMixin, Runner
+from ..model import Action, ActionKind, EngineId, InteractiveOption, InteractiveRequest, ResumeToken, TakopiEvent
+from ..runner import JsonlSubprocessRunner, JsonlStreamState, ResumeTokenMixin, Runner
 from .run_options import get_run_options
 from ..schemas import claude as claude_schema
 from .tool_actions import tool_input_path, tool_kind_and_title
@@ -34,6 +35,7 @@ class ClaudeStreamState:
     pending_actions: dict[str, Action] = field(default_factory=dict)
     last_assistant_text: str | None = None
     note_seq: int = 0
+    stdin: Any = None
 
 
 def _normalize_tool_result(content: Any) -> str:
@@ -296,6 +298,12 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             raise RuntimeError(f"resume token is for engine {token.engine!r}")
         return f"`claude --resume {token.value}`"
 
+    def keep_stdin_open(self) -> bool:
+        return not self.dangerously_skip_permissions
+
+    async def _after_send_payload(self, proc: Any, *, state: ClaudeStreamState) -> None:
+        state.stdin = proc.stdin
+
     def _build_args(self, prompt: str, resume: ResumeToken | None) -> list[str]:
         run_options = get_run_options()
         args: list[str] = ["-p", "--output-format", "stream-json", "--verbose"]
@@ -334,6 +342,10 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         *,
         state: Any,
     ) -> bytes | None:
+        # When using the control protocol (stdin stays open), send a newline
+        # immediately so claude doesn't block waiting for stdin at startup.
+        if self.keep_stdin_open():
+            return b"\n"
         return None
 
     def env(self, *, state: Any) -> dict[str, str] | None:
@@ -354,6 +366,135 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         state: ClaudeStreamState,
     ) -> None:
         pass
+
+    def _to_interactive_request(
+        self, ctrl_req: claude_schema.StreamControlRequest
+    ) -> InteractiveRequest | None:
+        req = ctrl_req.request
+        if not isinstance(req, claude_schema.ControlCanUseToolRequest):
+            return None
+        tool_name = req.tool_name or "tool"
+        description: str | None = None
+        if req.input:
+            cmd = req.input.get("command")
+            if isinstance(cmd, str):
+                description = cmd
+            else:
+                path = req.input.get("file_path") or req.input.get("path")
+                if isinstance(path, str):
+                    description = path
+        return InteractiveRequest(
+            request_id=ctrl_req.request_id,
+            kind="permission",
+            title=f"Allow {tool_name}?",
+            description=description,
+            options=[
+                InteractiveOption(id="allow", label="Allow"),
+                InteractiveOption(id="deny", label="Deny"),
+            ],
+        )
+
+    async def _send_control_response(
+        self,
+        request_id: str,
+        *,
+        ok: bool,
+        error: str | None = None,
+        send_to_stdin: Callable[[bytes], Awaitable[None]],
+    ) -> None:
+        if ok:
+            inner: claude_schema.ControlResponse = claude_schema.ControlSuccessResponse(
+                request_id=request_id
+            )
+        else:
+            inner = claude_schema.ControlErrorResponse(
+                request_id=request_id, error=error or "denied"
+            )
+        response = claude_schema.StreamControlResponse(response=inner)
+        encoded = msgspec.json.encode(response) + b"\n"
+        await send_to_stdin(encoded)
+
+    async def handle_interactive(
+        self,
+        request: InteractiveRequest,
+        *,
+        state: ClaudeStreamState,
+        send_to_stdin: Callable[[bytes], Awaitable[None]],
+    ) -> None:
+        run_opts = get_run_options()
+        handler = run_opts.interactive_handler if run_opts is not None else None
+        if handler is None:
+            await self._send_control_response(
+                request.request_id,
+                ok=False,
+                error="denied",
+                send_to_stdin=send_to_stdin,
+            )
+            return
+        try:
+            option_id = await handler(request)
+        except Exception:  # noqa: BLE001
+            option_id = "deny"
+        if option_id == "allow":
+            await self._send_control_response(
+                request.request_id, ok=True, send_to_stdin=send_to_stdin
+            )
+        else:
+            await self._send_control_response(
+                request.request_id,
+                ok=False,
+                error="denied",
+                send_to_stdin=send_to_stdin,
+            )
+
+    async def _process_control_request(
+        self,
+        ctrl_req: claude_schema.StreamControlRequest,
+        *,
+        state: ClaudeStreamState,
+    ) -> None:
+        assert state.stdin is not None
+
+        async def send_to_stdin(data: bytes) -> None:
+            await state.stdin.send(data)
+
+        ireq = self._to_interactive_request(ctrl_req)
+        if ireq is None:
+            await self._send_control_response(
+                ctrl_req.request_id, ok=True, send_to_stdin=send_to_stdin
+            )
+        else:
+            await self.handle_interactive(ireq, state=state, send_to_stdin=send_to_stdin)
+
+    async def _iter_jsonl_events(
+        self,
+        *,
+        stdout: Any,
+        stream: JsonlStreamState,
+        state: ClaudeStreamState,
+        resume: ResumeToken | None,
+        logger: Any,
+        pid: int,
+    ) -> AsyncIterator[TakopiEvent]:
+        async for raw_line in self.iter_json_lines(stdout):
+            line = raw_line.strip()
+            if line and state.stdin is not None:
+                try:
+                    decoded = self.decode_jsonl(line=line)
+                except Exception:  # noqa: BLE001
+                    decoded = None
+                if isinstance(decoded, claude_schema.StreamControlRequest):
+                    await self._process_control_request(decoded, state=state)
+                    continue
+            for evt in self._handle_jsonl_line(
+                raw_line=raw_line,
+                stream=stream,
+                state=state,
+                resume=resume,
+                logger=logger,
+                pid=pid,
+            ):
+                yield evt
 
     def decode_jsonl(
         self,

--- a/src/takopi/runners/opencode.py
+++ b/src/takopi/runners/opencode.py
@@ -9,6 +9,12 @@ OpenCode outputs JSON events in a streaming format with types:
 - step_finish: Marks the end of a step (with reason: "stop" or "tool-calls")
 
 Session IDs use the format: ses_XXXX (e.g., ses_494719016ffe85dkDMj0FPRbHK)
+
+Interactive permission support (future):
+When OpenCode emits approval events in JSON mode, add:
+1. Override keep_stdin_open() → True
+2. Override _iter_jsonl_events to detect approval events
+3. Override handle_interactive to map option → OpenCode's response format
 """
 
 from __future__ import annotations

--- a/src/takopi/runners/run_options.py
+++ b/src/takopi/runners/run_options.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..model import InteractiveRequest
 
 
 @dataclass(frozen=True, slots=True)
 class EngineRunOptions:
     model: str | None = None
     reasoning: str | None = None
+    interactive_handler: Callable[[InteractiveRequest], Awaitable[str]] | None = None
 
 
 _RUN_OPTIONS: ContextVar[EngineRunOptions | None] = ContextVar(

--- a/src/takopi/telegram/backend.py
+++ b/src/takopi/telegram/backend.py
@@ -68,6 +68,16 @@ def _build_startup_message(
             f"auto ({resolved_scope})" if topics.scope == "auto" else resolved_scope
         )
         topics_label = f"enabled (scope={scope_label})"
+    claude_runner = runtime.runner_for_engine("claude")
+    interactive_label: str | None = None
+    if claude_runner is not None:
+        skip = getattr(claude_runner, "dangerously_skip_permissions", True)
+        interactive_label = "disabled" if skip else "enabled"
+    interactive_line = (
+        f"interactive permissions: `{interactive_label}`  \n"
+        if interactive_label is not None
+        else ""
+    )
     return (
         f"\N{OCTOPUS} **takopi is ready**\n\n"
         f"default: `{runtime.default_engine}`  \n"
@@ -76,6 +86,7 @@ def _build_startup_message(
         f"mode: `{session_mode}`  \n"
         f"topics: `{topics_label}`  \n"
         f"resume lines: `{resume_label}`  \n"
+        f"{interactive_line}"
         f"working in: `{startup_pwd}`"
     )
 

--- a/src/takopi/telegram/commands/executor.py
+++ b/src/takopi/telegram/commands/executor.py
@@ -380,6 +380,17 @@ class _TelegramCommandExecutor(CommandExecutor):
         run_options = None
         if self._engine_overrides_resolver is not None:
             run_options = await self._engine_overrides_resolver(engine)
+        from ..interactive import TelegramInteractiveHandler
+
+        interactive_handler = TelegramInteractiveHandler(
+            transport=self._exec_cfg.transport,
+            chat_id=self._chat_id,
+        )
+        run_options = EngineRunOptions(
+            model=run_options.model if run_options is not None else None,
+            reasoning=run_options.reasoning if run_options is not None else None,
+            interactive_handler=interactive_handler,
+        )
         on_thread_known = (
             self._scheduler.note_thread_known
             if self._on_thread_known is None

--- a/src/takopi/telegram/interactive.py
+++ b/src/takopi/telegram/interactive.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any
+
+import anyio
+
+from ..logging import get_logger
+from ..model import InteractiveRequest
+from ..transport import MessageRef, RenderedMessage, SendOptions, Transport
+
+if TYPE_CHECKING:
+    pass
+
+logger = get_logger(__name__)
+
+INTERACTIVE_CB_PREFIX = "takopi:interactive"
+
+
+def make_interactive_markup(
+    *,
+    chat_id: int,
+    msg_id: int,
+    request_id: str,
+    options: list,
+) -> dict:
+    buttons = [
+        [
+            {
+                "text": opt.label,
+                "callback_data": f"{INTERACTIVE_CB_PREFIX}:{opt.id}:{chat_id}:{msg_id}:{request_id}",
+            }
+        ]
+        for opt in options
+    ]
+    return {"inline_keyboard": buttons}
+
+
+class TelegramInteractiveHandler:
+    def __init__(self, transport: Transport, chat_id: int) -> None:
+        self._transport = transport
+        self._chat_id = chat_id
+        self._progress_ref: MessageRef | None = None
+        self._pending: dict[str, anyio.Event] = {}
+        self._responses: dict[str, str] = {}
+
+    def _on_running_task_created(self, running_task: Any, progress_ref: MessageRef) -> None:
+        self._progress_ref = progress_ref
+        running_task.interactive_handler = self
+
+    def resolve(self, request_id: str, option_id: str) -> None:
+        self._responses[request_id] = option_id
+        event = self._pending.get(request_id)
+        if event is not None:
+            event.set()
+
+    async def __call__(self, request: InteractiveRequest) -> str:
+        if self._progress_ref is None:
+            logger.warning("interactive.no_progress_ref", request_id=request.request_id)
+            return "deny"
+
+        event = anyio.Event()
+        self._pending[request.request_id] = event
+        permission_msg_ref: MessageRef | None = None
+
+        try:
+            permission_msg_ref = await self._send_permission_message(request)
+
+            with anyio.move_on_after(60):
+                await event.wait()
+        finally:
+            self._pending.pop(request.request_id, None)
+
+        if permission_msg_ref is not None:
+            with contextlib.suppress(Exception):
+                await self._transport.delete(ref=permission_msg_ref)
+
+        return self._responses.pop(request.request_id, "deny")
+
+    async def _send_permission_message(
+        self, request: InteractiveRequest
+    ) -> MessageRef | None:
+        assert self._progress_ref is not None
+        chat_id = int(self._chat_id)
+        msg_id = int(self._progress_ref.message_id)
+
+        lines = [f"Permission: {request.title}"]
+        if request.description:
+            lines.append(f"`{request.description}`")
+        text = "\n".join(lines)
+
+        markup = make_interactive_markup(
+            chat_id=chat_id,
+            msg_id=msg_id,
+            request_id=request.request_id,
+            options=request.options,
+        )
+
+        rendered = RenderedMessage(text=text, extra={"reply_markup": markup})
+        try:
+            return await self._transport.send(
+                channel_id=self._chat_id,
+                message=rendered,
+                options=SendOptions(reply_to=self._progress_ref, notify=True),
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "interactive.send_failed", request_id=request.request_id
+            )
+            return None
+
+
+async def handle_callback_interactive(
+    cfg: Any,
+    query: Any,
+    running_tasks: Any,
+) -> None:
+    data = query.data or ""
+    # Format: takopi:interactive:{opt_id}:{chat_id}:{msg_id}:{request_id}
+    parts = data.split(":", 5)
+    if len(parts) != 6:
+        await cfg.bot.answer_callback_query(query.callback_query_id)
+        return
+
+    _, _, opt_id, chat_id_str, msg_id_str, request_id = parts
+    try:
+        progress_chat_id = int(chat_id_str)
+        progress_msg_id = int(msg_id_str)
+    except ValueError:
+        await cfg.bot.answer_callback_query(query.callback_query_id)
+        return
+
+    ref = MessageRef(channel_id=progress_chat_id, message_id=progress_msg_id)
+    task = running_tasks.get(ref)
+    if task is None or task.interactive_handler is None:
+        await cfg.bot.answer_callback_query(
+            query.callback_query_id, text="Permission request expired."
+        )
+        return
+
+    task.interactive_handler.resolve(request_id, opt_id)
+    confirmation = "Allowed." if opt_id == "allow" else "Denied."
+    await cfg.bot.answer_callback_query(
+        query.callback_query_id, text=confirmation
+    )

--- a/src/takopi/telegram/loop.py
+++ b/src/takopi/telegram/loop.py
@@ -25,6 +25,7 @@ from ..transport_runtime import ResolvedMessage
 from ..context import RunContext
 from ..ids import RESERVED_CHAT_COMMANDS
 from .bridge import CANCEL_CALLBACK_DATA, TelegramBridgeConfig, send_plain
+from .interactive import INTERACTIVE_CB_PREFIX, handle_callback_interactive
 from .commands.cancel import handle_callback_cancel, handle_cancel
 from .commands.file_transfer import FILE_PUT_USAGE
 from .commands.handlers import (
@@ -1838,6 +1839,15 @@ async def run_main_loop(
                             update,
                             state.running_tasks,
                             scheduler,
+                        )
+                    elif update.data and update.data.startswith(
+                        INTERACTIVE_CB_PREFIX + ":"
+                    ):
+                        tg.start_soon(
+                            handle_callback_interactive,
+                            cfg,
+                            update,
+                            state.running_tasks,
                         )
                     else:
                         tg.start_soon(

--- a/src/takopi/transport_runtime.py
+++ b/src/takopi/transport_runtime.py
@@ -144,6 +144,15 @@ class TransportRuntime:
     def missing_engine_ids(self) -> tuple[EngineId, ...]:
         return self.engine_ids_with_status("missing_cli")
 
+    def runner_for_engine(self, engine_id: EngineId) -> Runner | None:
+        from .router import RunnerUnavailableError
+
+        try:
+            entry = self._router.entry_for_engine(engine_id)
+            return entry.runner if entry.available else None
+        except RunnerUnavailableError:
+            return None
+
     def project_aliases(self) -> tuple[str, ...]:
         return tuple(project.alias for project in self._projects.projects.values())
 

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -13,6 +13,7 @@ from takopi.runners.claude import (
     ENGINE,
     translate_claude_event,
 )
+from takopi.runners.run_options import EngineRunOptions, apply_run_options
 from takopi.schemas import claude as claude_schema
 
 
@@ -423,3 +424,38 @@ async def test_run_strips_anthropic_api_key_by_default(tmp_path, monkeypatch) ->
         if isinstance(event, CompletedEvent):
             answer = event.answer
     assert answer == "api=set"
+
+
+def test_dangerously_skip_permissions_adds_flag() -> None:
+    runner = ClaudeRunner(claude_cmd="claude", dangerously_skip_permissions=True)
+    args = runner._build_args("hello", None)
+    assert "--dangerously-skip-permissions" in args
+
+
+def test_dangerously_skip_permissions_false_omits_flag() -> None:
+    runner = ClaudeRunner(claude_cmd="claude", dangerously_skip_permissions=False)
+    args = runner._build_args("hello", None)
+    assert "--dangerously-skip-permissions" not in args
+
+
+def test_dangerously_skip_permissions_flag_even_with_interactive_handler() -> None:
+    """--dangerously-skip-permissions must be passed even when an interactive handler
+    is present, so that explicit config is respected and stdin stays closed."""
+    runner = ClaudeRunner(claude_cmd="claude", dangerously_skip_permissions=True)
+
+    async def fake_handler(request):  # type: ignore[no-untyped-def]
+        return "allow"
+
+    opts = EngineRunOptions(interactive_handler=fake_handler)
+    with apply_run_options(opts):
+        args = runner._build_args("hello", None)
+
+    assert "--dangerously-skip-permissions" in args
+
+
+def test_keep_stdin_open_matches_skip_permissions() -> None:
+    skip = ClaudeRunner(claude_cmd="claude", dangerously_skip_permissions=True)
+    no_skip = ClaudeRunner(claude_cmd="claude", dangerously_skip_permissions=False)
+
+    assert skip.keep_stdin_open() is False
+    assert no_skip.keep_stdin_open() is True

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "takopi"
-version = "0.22.3"
+version = "0.22.4"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- Adds interactive permission handling for Claude Code runner, allowing tool approval/denial via Telegram inline buttons
- Implements `TelegramInteractiveHandler` with callback routing, 60s timeout with auto-deny
- Bridges interactive requests through `EngineRunOptions` and `RunnerBridge` to the Telegram transport

Closes #195

## Test plan
- [ ] Test interactive permission prompts appear as inline buttons in Telegram
- [ ] Test approve/deny responses are routed back to the runner
- [ ] Test 60s timeout auto-denies and cleans up the message
- [ ] Test concurrent permission requests don't interfere

🤖 Generated with [Claude Code](https://claude.com/claude-code)