### PR TITLE
feat: permission management from Telegram

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -201,7 +201,7 @@ flowchart TD
     B --> C[Build Command]
 
     C --> D{Engine?}
-    D -->|Claude| D1["claude --print --output-format stream-json<br/>[--resume id] prompt"]
+    D -->|Claude| D1["claude --print --input-format stream-json<br/>--output-format stream-json<br/>[--resume id] (prompt on stdin)"]
     D -->|Codex| D2["codex exec --json<br/>[resume &lt;token&gt;] -"]
     D -->|Pi| D3["pi --print --mode json<br/>--session &lt;id&gt; &lt;prompt&gt;"]
     D -->|OpenCode| D4["opencode run --format json<br/>[--session id] -- &lt;prompt&gt;"]

--- a/docs/reference/runners/claude/runner.md
+++ b/docs/reference/runners/claude/runner.md
@@ -16,7 +16,7 @@ Provide the **`claude`** engine backend so Takopi can:
 
 * Interactive Q&A inside a single run (e.g., answering `AskUserQuestion` prompts mid-flight).
 * Full “slash commands” integration (Claude Code docs note many slash commands are interactive-only). ([Claude Code][1])
-* MCP prompt-handling for permissions (use allow rules instead).
+* MCP prompt-handling (use allow rules instead).
 
 ---
 
@@ -50,13 +50,20 @@ Takopi should parse either:
 
 **Note:** Claude session IDs should be treated as **opaque strings**. Do not assume UUID format.
 
-### Permissions / non-interactive runs
+### Permissions / interactive tool approvals
 
-In `-p` mode, Claude Code can require tool approvals. Takopi cannot click/answer interactive prompts, so **users must preconfigure permissions** (via Claude Code settings or `--allowedTools`). Claude’s settings system supports allow/deny tool rules. ([Claude Code][2])
+Claude Code emits `StreamControlRequest` events when a tool requires permission. Takopi handles these interactively via Telegram:
+
+* **Tool approval prompts** (`ControlCanUseToolRequest`): Takopi sends a separate Telegram message with inline keyboard buttons (Allow / Deny). The user taps a button and the response is written back to Claude’s stdin as a `StreamControlResponse`.
+* **Auto-acknowledged requests** (`ControlInitializeRequest`, `ControlSetPermissionModeRequest`): Takopi sends a success response automatically.
+* **Unsupported requests** (`ControlInterruptRequest`, `ControlHookCallbackRequest`, `ControlMcpMessageRequest`, `ControlRewindFilesRequest`): Takopi sends an error response ("not supported").
+* **Timeout**: If the user does not respond within 5 minutes, Takopi sends a `{"error": "timed out"}` response to Claude and edits the Telegram prompt message to "timed out".
+
+This requires `--input-format stream-json` to keep stdin open for bidirectional communication.
+
+Users can still preconfigure permissions (via Claude Code settings or `--allowedTools`) to reduce prompt frequency. Claude’s settings system supports allow/deny tool rules. ([Claude Code][2])
 
 **Safety note:** `-p/--print` skips the workspace trust dialog; only use this flag in trusted directories.
-
-Takopi should document this clearly: if permissions aren’t configured and Claude tries to use a gated tool, the run may block or fail.
 
 ---
 
@@ -142,7 +149,7 @@ Use Agent SDK CLI non-interactively:
 
 Core invocation:
 
-* `claude -p --output-format stream-json --verbose` ([Claude Code][1])
+* `claude -p --input-format stream-json --output-format stream-json --verbose` ([Claude Code][1])
   * `--verbose` overrides config and is required for full stream-json output.
 
 Resume:
@@ -160,7 +167,7 @@ Permissions:
 
 Prompt passing:
 
-* Pass the prompt as the final positional argument after `--` (CLI expects `prompt` as an argument). This also protects prompts that begin with `-`. ([Claude Code][1])
+* Use `--input-format stream-json` and send the prompt as a stream-json user message on stdin. This keeps stdin open for bidirectional communication (tool approval responses). The prompt is encoded as `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"..."}]}}`. ([Claude Code][1])
 
 Other flags:
 

--- a/docs/reference/runners/claude/stream-json-cheatsheet.md
+++ b/docs/reference/runners/claude/stream-json-cheatsheet.md
@@ -1,7 +1,7 @@
 # Claude `stream-json` event cheatsheet
 
-`claude -p --output-format stream-json --verbose` writes **one JSON object per line**
-(JSONL) with a required `type` field. (`--output-format` only works with `-p`.)
+`claude -p --input-format stream-json --output-format stream-json --verbose` writes **one JSON object per line**
+(JSONL) with a required `type` field. (`--output-format` only works with `-p`; `--input-format stream-json` keeps stdin open for prompt delivery and tool approval responses.)
 
 This cheatsheet is derived from `humanlayer/claudecode-go/types.go` and
 `client_test.go`.

--- a/docs/reference/runners/claude/takopi-events.md
+++ b/docs/reference/runners/claude/takopi-events.md
@@ -13,19 +13,24 @@ The goal is to make a Claude runner feel identical to the Codex runner from the 
 Claude Code CLI emits **one JSON object per line** (JSONL) when invoked with
 `--output-format stream-json` (only valid with `-p/--print`).
 
-Recommended invocation (matches claudecode-go):
+Recommended invocation:
 
 ```
-claude -p --output-format stream-json --verbose -- <query>
+claude -p --input-format stream-json --output-format stream-json --verbose
+```
+
+The prompt is sent on **stdin** as a stream-json user message:
+
+```json
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"<query>"}]}}
 ```
 
 Notes:
-- `--verbose` is required for `stream-json` output (clis may otherwise drop events).
-- `-p/--print` is required for `--output-format` and `--include-partial-messages`.
-- `-- <query>` is required to safely pass prompts that start with `-`.
+- `--verbose` is required for `stream-json` output (CLIs may otherwise drop events).
+- `-p/--print` is required for `--output-format`.
+- `--input-format stream-json` keeps stdin open for bidirectional communication
+  (prompt delivery and tool approval responses).
 - Resuming uses `--resume <session_id>` and optional `--fork-session`.
-- The CLI does **not** read the prompt from stdin in claudecode-go; it passes the
-  prompt as the final positional argument after `--`.
 
 ---
 

--- a/docs/superpowers/specs/2026-03-21-permission-management-design.md
+++ b/docs/superpowers/specs/2026-03-21-permission-management-design.md
@@ -1,0 +1,515 @@
+# Permission Management from Telegram
+
+**Date:** 2026-03-21
+**Branch:** `feat/interactive-prompts`
+**Related issues:** #195, #207, #116, #206
+
+---
+
+## Context & Findings
+
+### The Problem
+
+Takopi users have no visibility or control over engine permission settings from Telegram. When a tool is denied, the session either hangs indefinitely (the original #195 bug) or completes with cryptic error text that doesn't explain what happened or how to fix it. Users resort to `dangerously_skip_permissions` as a blunt workaround.
+
+### What We Investigated
+
+We tested the Claude Code CLI's `control_request` protocol extensively and discovered:
+
+1. **`-p` mode never emits `control_request` events.** Claude auto-denies unapproved tools internally, returning an error `tool_result` like "Claude requested permissions to use X, but you haven't granted it yet." No interactive approval event reaches stdout.
+
+2. **The Agent SDK protocol (`--permission-prompt-tool stdio`) is broken.** [SDK issue #469](https://github.com/anthropics/claude-agent-sdk-python/issues/469) confirms that `can_use_tool` callbacks never fire, reproduced across CLI versions 2.1.6 through 2.1.73 (March 2026). Multiple users confirmed.
+
+3. **Claude's plan mode (`ExitPlanMode`) deadlocks in headless mode.** `ExitPlanMode` is a `tool_use` that triggers a `PermissionRequest` dialog — a separate system from `control_request`. It doesn't fire in `-p` mode, and even `PermissionRequest` hooks don't reliably work ([Claude issue #15755](https://github.com/anthropics/claude-code/issues/15755)).
+
+4. **Codex has no interactive approval in `exec --json` mode.** Approval events are silently dropped by the JSONL processor. Declined commands surface as `status: "declined"` on completed items. Interactive approval only exists in `codex app-server` (JSON-RPC 2.0), which is a completely different protocol.
+
+5. **`permission_denials` data exists but is invisible.** Claude's `result` event includes a `permission_denials` array with tool names and inputs, but takopi's `StreamResultMessage` schema doesn't declare the field — msgspec silently drops it.
+
+6. **The Untether fork's approach is fragile.** Their 2,067-line Claude runner with PTY-based stdin, global registries, and plan mode state machine has [open bugs where the event loop freezes](https://github.com/littlebearapps/untether/issues/156) after permission requests.
+
+### What Works Today
+
+| Mechanism | Claude | Codex |
+|---|---|---|
+| Pre-approve tools before run | `--allowedTools` | `--sandbox`, `-c sandbox_permissions` |
+| Permission mode | `--permission-mode acceptEdits\|bypassPermissions` | `-c approval_policy=never` (exec default) |
+| Web search | `--allowedTools WebSearch` | `-c web_search=live` |
+| Network access | Built-in (always available) | `-c sandbox_permissions=["network-full-access"]` |
+| Per-tool control | Fine-grained (`Bash`, `Read`, `mcp__server__*`) | Coarse (sandbox mode, network on/off) |
+| Mid-session changes | No (next run only) | No (next run only) |
+| Interactive approval | Broken (SDK #469) | Not available in exec mode |
+
+### Design Principles
+
+1. **Work with what the engines give us today** — don't depend on broken protocols
+2. **Pre-run configuration over mid-run interactivity** — both engines only support config at launch
+3. **Make denials visible and actionable** — show what was denied, offer one-tap fix
+4. **Engine-agnostic command, engine-specific behavior** — `/tools` works for all engines
+5. **Incremental delivery** — Phase A is independently valuable, B and C build on it
+
+---
+
+## Architecture Overview
+
+```
+User in Telegram
+    │
+    ├── /tools claude add WebSearch     ← Phase A: manage allowed tools
+    ├── /tools codex search live        ← Phase A: manage codex settings
+    │
+    ▼
+EngineOverrides (topic scope → chat scope → config → default)
+    │  Stored in TopicStateStore (per-topic) and ChatPrefsStore (per-chat)
+    │  Topic overrides take precedence, same as /model and /reasoning
+    │
+    ├── claude: { allowed_tools: [...], permission_mode: "acceptEdits" }
+    ├── codex:  { search: "live" }  ← only explicitly set values; rest inherited
+    │
+    ▼
+Engine runner (build_args)
+    │
+    ├── claude: --allowedTools Bash,Read,Edit,Write,WebSearch --permission-mode acceptEdits
+    ├── codex:  -c web_search=live  ← sandbox/network omitted when inherited
+    │
+    ▼
+Stream-json output
+    │
+    ├── permission_denials in result event  ← Phase A: surface as warnings
+    ├── denied tool names                   ← Phase B: inline "Add" buttons
+    │
+    ▼
+Telegram progress message
+    │
+    ├── "⚠ WebSearch denied"               ← Phase A: visible in progress
+    ├── [Add to allowed] button             ← Phase B: one-tap fix
+    └── Plan review + approve flow          ← Phase C: system-prompt plan mode
+```
+
+---
+
+## Phase A: Denial Visibility + `/tools` Command
+
+**Goal:** Users see what was denied and can fix it for next run.
+
+### A1. Surface `permission_denials` as Warning Events
+
+**Problem:** `StreamResultMessage` doesn't declare `permission_denials`, so msgspec drops it.
+
+**Changes:**
+
+`schemas/claude.py` — add field to `StreamResultMessage`:
+```python
+permission_denials: list[dict[str, Any]] | None = None
+```
+
+`runners/claude.py` — in `translate_claude_event`, after handling `StreamResultMessage`, emit warning `ActionEvent`s for each denial before the `CompletedEvent`:
+```python
+case claude_schema.StreamResultMessage(permission_denials=denials, ...) if denials:
+    events = []
+    for denial in denials:
+        tool_name = denial.get("tool_name", "unknown")
+        events.append(factory.action(
+            phase="completed",
+            action_id=f"claude.denied.{tool_name}",
+            kind="warning",
+            title=f"denied: {tool_name}",
+            detail=denial,
+        ))
+    events.append(factory.completed(...))  # existing completed event
+    return events
+```
+
+`model.py` — `"warning"` is already in `ActionKind` (if not, add it).
+
+The `ProgressTracker` already passes through `"warning"` kind events (it only filters `"turn"` and `"prompt"`), so these will appear in the progress message automatically.
+
+For Codex, `status: "declined"` on command execution items already surfaces as `ok=False`. No schema change needed, but we should ensure the declined tool name appears in the event title.
+
+**Files changed:** `schemas/claude.py`, `runners/claude.py` (+ possibly `runners/codex.py`)
+**Tests:** Add fixture with `permission_denials`, test warning events are emitted.
+
+### A2. Add `permission_mode` Config for Claude
+
+**Problem:** Users with `defaultMode: "plan"` in `~/.claude/settings.json` get stuck.
+
+**Changes:**
+
+`runners/claude.py` — add field to `ClaudeRunner`:
+```python
+permission_mode: str | None = None
+```
+
+In `_build_args`, after the `--allowedTools` block:
+```python
+if self.permission_mode is not None:
+    args.extend(["--permission-mode", self.permission_mode])
+```
+
+In `build_runner`:
+```python
+permission_mode = config.get("permission_mode")
+```
+
+**Config:**
+```toml
+[claude]
+permission_mode = "acceptEdits"
+```
+
+**Files changed:** `runners/claude.py`
+**Tests:** Test `_build_args` includes `--permission-mode` when set.
+
+### A3. Add Codex Sandbox/Search/Network Config
+
+**Problem:** Takopi passes no sandbox settings to Codex, relying entirely on user's config file. Users have no way to adjust these from Telegram.
+
+**Changes:**
+
+`runners/codex.py` — add fields to `CodexRunner`:
+```python
+sandbox_mode: str | None = None       # workspace-write | read-only | danger-full-access
+web_search: str | None = None         # live | cached | disabled
+network_access: bool | None = None    # enables network-full-access sandbox permission
+```
+
+In `build_args`, inject `-c` flags only when explicitly set (inherit from codex config by default):
+```python
+if self.sandbox_mode is not None:
+    args.extend(["-c", f"sandbox_mode={self.sandbox_mode}"])
+if self.web_search is not None:
+    args.extend(["-c", f"web_search={self.web_search}"])
+if self.network_access is True:
+    args.extend(["-c", 'sandbox_permissions=["network-full-access"]'])
+```
+
+**Network access is enable-only.** Codex's `sandbox_permissions` is an additive grant list — there is no CLI mechanism to force-disable network if the user's `~/.codex/config.toml` already enables it. When `network_access` is `None` or `False`, takopi simply omits the flag and inherits whatever the user's Codex config provides. The `/tools` command surfaces this honestly (see display format below).
+
+At runtime, `EngineRunOptions` values (from Telegram `/tools` overrides) take precedence over static config, which takes precedence over Codex's own config. When nothing is set, Codex uses its own defaults.
+
+In `build_runner`, read from config:
+```python
+sandbox_mode = config.get("sandbox_mode")
+web_search = config.get("web_search")
+network_access = config.get("network_access")
+```
+
+**Config (optional — all default to inherit):**
+```toml
+[codex]
+# sandbox_mode = "workspace-write"  # uncomment to override codex config
+# web_search = "live"               # uncomment to enable web search
+# network_access = false            # uncomment to control network access
+```
+
+**Files changed:** `runners/codex.py`
+**Tests:** Test `build_args` includes correct `-c` flags.
+
+### A4. `/tools` Telegram Command
+
+**Problem:** No way to manage engine permissions from Telegram.
+
+**Command syntax:**
+
+```
+/tools                              → show settings for current/default engine
+/tools claude                       → show claude allowed_tools + permission_mode
+/tools claude add WebSearch         → add to allowed_tools
+/tools claude add mcp__context7__*  → allow all tools from MCP server
+/tools claude remove Bash           → remove from allowed_tools
+/tools claude set Read,Write,Edit   → replace entire list
+/tools claude mode acceptEdits      → set permission_mode
+/tools codex                        → show codex sandbox/search/network
+/tools codex sandbox write          → workspace-write
+/tools codex sandbox full           → danger-full-access
+/tools codex sandbox readonly       → read-only
+/tools codex search live            → enable web search
+/tools codex network on             → grant network access for this chat
+/tools codex network off            → stop granting (inherit from codex config)
+```
+
+Note: `/tools codex network off` removes takopi's network grant — it does **not** force-disable network if the user's Codex config already enables it. Codex's sandbox_permissions model is additive; takopi can grant access but cannot revoke what the user's own config provides.
+
+**Display format** (for `/tools claude`):
+```
+Claude tools:
+  Allowed: Bash, Read, Edit, Write (override)
+  Mode: acceptEdits (config)
+  MCP servers: context7, github
+
+  /tools claude add <tool>
+  /tools claude add mcp__<server>__*
+```
+
+Each setting shows its source: `(override)` for Telegram-set values, `(config)` for `takopi.toml`, `(default)` for code fallback. For Codex:
+```
+Codex settings:
+  Sandbox: inherited
+  Search: live (override)
+  Network: inherited
+
+  /tools codex sandbox write|full|readonly
+  /tools codex search live|cached|disabled
+  /tools codex network on|off
+```
+
+"inherited" means takopi passes no flag and Codex uses its own config. For network, `on` grants access via takopi; `off` removes the grant (but cannot override Codex's own config if it already enables network).
+
+**Persistence:** Add to `EngineOverrides` struct in `engine_overrides.py`:
+```python
+class EngineOverrides(msgspec.Struct, forbid_unknown_fields=False):
+    model: str | None = None
+    reasoning: str | None = None
+    allowed_tools: list[str] | None = None
+    permission_mode: str | None = None
+    # Codex-specific (None = inherit from codex config)
+    sandbox_mode: str | None = None
+    web_search: str | None = None
+    network_access: bool | None = None  # True = grant; None/False = inherit
+```
+
+These override the static config values from `takopi.toml` at runtime. Telegram overrides take precedence over config file values, with topic-over-chat precedence (same as `/model` and `/reasoning`).
+
+**Runtime flow:**
+1. `/tools claude add WebSearch` → handler reads current effective list, appends `WebSearch`, writes full list to `EngineOverrides.allowed_tools` via `apply_engine_override()` (topic-scoped when in a topic, chat-scoped otherwise)
+2. Next run: `_resolve_engine_run_options()` merges topic + chat overrides (topic wins)
+3. `EngineRunOptions` carries the `allowed_tools` override to the runner
+4. Runner's `_build_args` uses the override if set, otherwise falls back to static config
+
+This requires extending `EngineRunOptions` to carry tool settings:
+```python
+@dataclass(frozen=True, slots=True)
+class EngineRunOptions:
+    model: str | None = None
+    reasoning: str | None = None
+    allowed_tools: list[str] | None = None
+    permission_mode: str | None = None
+    sandbox_mode: str | None = None
+    web_search: str | None = None
+    network_access: bool | None = None
+```
+
+**New files:**
+- `telegram/commands/tools.py` — command handler
+
+**Modified files:**
+- `ids.py` — add `"tools"` to `RESERVED_CHAT_COMMANDS`
+- `telegram/loop.py` — add dispatch branch in `_dispatch_builtin_command`
+- `telegram/commands/handlers.py` — re-export
+- `telegram/commands/menu.py` — add to bot command list
+- `telegram/engine_overrides.py` — extend `EngineOverrides`
+- `runners/run_options.py` — extend `EngineRunOptions`
+- `runners/claude.py` — read tool settings from `run_options`
+- `runners/codex.py` — read sandbox/search/network from `run_options`
+
+**Tests:** Command parsing, override persistence, integration with runner args.
+
+### A5. Show MCP Server Names in `/tools` Output
+
+The `system/init` message includes `mcp_servers: [{name, status}]`. We can capture this during the first event of a session and display it in `/tools` output, so users know what servers are available for wildcard allows.
+
+This is informational only — no new protocol needed. The data is already in `StreamSystemMessage.mcp_servers`.
+
+**Files changed:** Minimal — read `mcp_servers` from init event, store on `ClaudeStreamState`, surface in `/tools` display (could be deferred if complex).
+
+---
+
+## Phase B: Reactive Denial Notifications with Inline Buttons
+
+**Goal:** When a tool is denied, offer one-tap fix.
+
+**Depends on:** Phase A (denial visibility, `/tools` persistence)
+
+### B1. Denial Notification Messages
+
+When a `permission_denials` warning event is emitted, instead of just showing it in the progress message, send a separate Telegram message with inline keyboard buttons:
+
+```
+⚠ WebSearch denied (not in allowed tools)
+[Add WebSearch]  [Add all from server]
+```
+
+For MCP tools:
+```
+⚠ mcp__context7__resolve-library-id denied
+[Add this tool]  [Add all context7]
+```
+
+**Callback format:**
+```
+takopi:addtool:{engine}:{chat_msg_id}:{tool_pattern}
+```
+
+**Handler:** On button press:
+1. Read current effective allowed_tools for the engine
+2. Append the tool pattern, write the full list via `apply_engine_override()` (topic-scoped when the callback originates from a topic, chat-scoped otherwise — same scoping as `/tools`)
+3. Edit the message to confirm: "Added WebSearch to allowed tools"
+4. Clear inline keyboard
+
+**Limitation:** This fixes the NEXT run, not the current one. The message should say "Added for future runs" to set expectations.
+
+### B2. Denial Summary in Completed Message
+
+After a run completes with denials, append a summary line to the final message:
+```
+⚠ 2 tools denied: WebSearch, mcp__context7__resolve-library-id
+```
+
+This uses the denial data already captured in Phase A.
+
+**Files changed:** `runner_bridge.py` (final message rendering), `telegram/bridge.py` (new callback handler), `telegram/loop.py` (callback routing)
+
+---
+
+## Phase C: Soft Plan Mode + Extended Settings
+
+**Goal:** Enable plan-review workflow without relying on broken `ExitPlanMode`.
+
+**Depends on:** Phase A + B
+
+### C1. System-Prompt Plan Mode
+
+Instead of `--permission-mode plan` (which deadlocks), inject planning instructions via `--append-system-prompt`:
+
+```
+Before making any code changes, first produce a detailed plan.
+Present the plan as a numbered list of steps.
+After presenting the plan, stop and wait for the user to approve it
+before proceeding with implementation.
+```
+
+**UX flow:**
+1. User sends `/plan on` (or `/tools claude plan on`)
+2. Takopi stores the plan preference in `ChatPrefsStore`
+3. Next run: `--append-system-prompt` with planning instructions
+4. Claude produces a plan in the assistant text (visible in progress message)
+5. Claude stops (either naturally or by calling `AskUserQuestion`)
+6. User reviews the plan in Telegram, sends "approved" or "change X" as a follow-up message
+7. Claude continues with implementation in the same session (via `--resume`)
+
+**Why this works:** No `ExitPlanMode`, no `control_request`, no blocking. Claude's text output is already rendered in the progress message. The "approval" is just a normal follow-up message in the conversation.
+
+**Limitation:** Claude might not always stop after the plan (it's a soft instruction, not an enforcement). To mitigate: use `--max-turns 1` for the planning phase, then `--resume` with approval for the execution phase. Or use a `PreToolUse` hook that blocks Write/Edit/Bash during planning.
+
+### C2. Codex App-Server Mode (Future)
+
+If per-command interactive approval is needed for Codex, this requires switching from `exec --json` to the app-server JSON-RPC protocol. This is a large architectural change:
+
+- New transport: bidirectional JSON-RPC 2.0 over stdio
+- New handshake: `initialize` → `initialized` → `thread/start` → `turn/start`
+- New approval flow: `requestApproval` server-request → Telegram buttons → `serverRequest/resolved`
+- Per-command elevation: `acceptWithExecpolicyAmendment`
+- Per-host network approval: `networkApprovalContext`
+
+**Scope:** This is essentially a new runner, not a modification of the existing one. Estimated at 800+ lines. Should only be pursued if there's strong demand for per-command Codex approval from Telegram.
+
+### C3. Dynamic Permission Mode Switching
+
+If/when Claude fixes the `control_request` protocol (SDK #469), enable runtime switching:
+- `/tools claude mode plan` → sets `--permission-mode plan` and activates the interactive prompt infrastructure from the current branch
+- `ExitPlanMode` control_request → Telegram buttons → approve/reject
+- `ControlCanUseToolRequest` → Telegram buttons → allow/deny/always
+
+This reactivates the code already written on this branch. Gate it behind a config flag (`control_protocol = true`) until the CLI bug is fixed.
+
+---
+
+## Resume + Changed Settings
+
+Both runners spawn a **new subprocess** for every message. When a user changes settings via `/tools` between messages, the next run picks them up immediately while preserving conversation context:
+
+- **Claude:** `claude -p --resume <session_id> --allowedTools X,Y,Z` — the `--resume` flag restores conversation context from Claude's session storage, but `--allowedTools` and `--permission-mode` are applied fresh from the new process args.
+
+- **Codex:** `codex [-c sandbox_mode=...] exec --json resume <thread_id> -` — same pattern. The `-c` flags are process-level. A new process with new flags resumes the thread with new sandbox settings.
+
+This means `/tools claude add WebSearch` takes effect on the very next message in the same conversation. No restart needed.
+
+---
+
+## What Happens to the Current Branch
+
+The `feat/interactive-prompts` branch has substantial infrastructure for the `control_request` protocol:
+- `StreamControlRequest` handling in `runners/claude.py`
+- Prompt bridge in `runner_bridge.py` (`pending_prompts`, `prompt_responses`, `prompt_responders`, `_wait_prompt_response`)
+- `encode_control_response` in `schemas/claude.py`
+- Telegram interactive handler in `telegram/bridge.py` (`handle_callback_prompt`, `prompt_markup`, `format_prompt_text`)
+- `keep_stdin_open`, `set_stdin_stream`, `flush_stdin_writes` in `runner.py`
+- `--input-format stream-json` stdin message protocol in `runners/claude.py`
+- 787 lines of tests across 3 files (`test_claude_runner.py`, `test_exec_bridge.py`, `test_prompt_bridge.py`)
+
+**Recommendation: keep all of this code.** The implementation is correct and well-tested — it's the Claude CLI that has the bug ([SDK #469](https://github.com/anthropics/claude-agent-sdk-python/issues/469)). Our code already handles:
+- `ControlInitializeRequest` / `ControlSetPermissionModeRequest` auto-responses
+- `ControlCanUseToolRequest` → prompt ActionEvent → Telegram buttons → `control_response`
+- stdin locking, batched writes, proper cleanup on cancel/timeout
+- 300s timeout with message editing ("timed out" / "cancelled")
+
+**Gating strategy:** Add a `control_protocol` config flag to `[claude]`:
+
+```toml
+[claude]
+control_protocol = false   # default: use -p mode (reliable today)
+# control_protocol = true  # enable when Claude fixes SDK #469
+```
+
+When `control_protocol = false` (default):
+- Uses `-p` flag (current reliable behavior)
+- `--allowedTools` for pre-run tool approval
+- `permission_denials` in result event for post-run visibility (Phase A)
+- A6 makes `keep_stdin_open` return `False`, reverting to base-class stdin behavior (close after payload)
+
+When `control_protocol = true`:
+- Removes `-p`, uses `--input-format stream-json` + `--permission-prompt-tool stdio`
+- Keeps stdin open for bidirectional control protocol
+- `StreamControlRequest` events → Telegram inline buttons → `StreamControlResponse`
+- Interactive tool approval, `AskUserQuestion`, and (if Claude fixes it) `ExitPlanMode`
+
+The flag selects between two code paths in `_build_args` and `keep_stdin_open`. All the existing branch code stays intact, just dormant behind the flag. When Anthropic ships the fix:
+1. User sets `control_protocol = true`
+2. Interactive prompts activate immediately
+3. No code changes needed in takopi
+
+---
+
+## Implementation Order
+
+### Phase A (target: this PR)
+1. **A1** — `permission_denials` schema field + warning events (~30 lines)
+2. **A2** — `permission_mode` config for Claude (~10 lines)
+3. **A3** — Codex `sandbox_mode` / `web_search` / `network_access` config (~30 lines)
+4. **A4** — `/tools` command + `EngineOverrides` extension + persistence (~250 lines)
+5. **A5** — MCP server names in `/tools` output (~20 lines)
+6. **A6** — `control_protocol` gate flag for existing branch code (~20 lines)
+7. Tests for all of the above (~200 lines)
+
+**Total Phase A:** ~560 lines
+
+### Phase B (follow-up PR)
+1. **B1** — Denial notification messages with inline **[Add to allowed]** buttons (~150 lines)
+2. **B2** — Denial summary in completed message (~30 lines)
+3. Tests (~100 lines)
+
+**Total Phase B:** ~280 lines
+
+### Phase C (future)
+1. **C1** — System-prompt plan mode via `--append-system-prompt` (~100 lines)
+2. **C2** — Codex app-server mode for interactive approval (~800 lines, separate feature)
+3. **C3** — Flip `control_protocol = true` as default when SDK #469 is resolved
+
+---
+
+## Design Decisions (resolved)
+
+1. **Persistence model for allowed_tools: replacement, not union.**
+   The `/tools` UX supports additive commands (`add`, `remove`), but at the persistence layer the override stores the **full effective list**. When the user runs `/tools claude add WebSearch`, the handler reads the current effective list, appends `WebSearch`, and writes the complete new list to `EngineOverrides.allowed_tools`. This avoids ambiguity around removals and stays consistent with the existing override model where fields are simple replacements with topic-over-chat precedence.
+
+2. **Override scope: per-topic + per-chat, matching existing pattern.**
+   `/tools` overrides follow the same scoping as `/model` and `/reasoning`: stored at topic scope when a topic key exists, falling back to chat scope otherwise. Uses `apply_engine_override()` from `commands/overrides.py` which already handles this selection. No new exception in the override model.
+
+3. **Admin restriction: mutating subcommands only.**
+   `/tools` (show) and `/tools claude` (show) are readable by anyone. Mutating subcommands (`add`, `remove`, `set`, `mode`, `sandbox`, `search`, `network`) require `require_admin_or_private`, matching `/model` and `/reasoning`.
+
+4. **Claude default allowed_tools: restore master default.**
+   Master has `DEFAULT_ALLOWED_TOOLS = ["Bash", "Read", "Edit", "Write"]`, matching all documentation. Our branch reduced this to `["Bash", "Read"]` during the interactive-prompts work (when the control protocol was expected to handle approvals interactively). Since we're gating the control protocol behind a flag and keeping `-p` mode as default, **restore the 4-tool default** from master. For `/tools` display, show the **effective list** — whatever the runner will actually pass as `--allowedTools` — and label its source (config, override, or code default).
+
+5. **Codex sandbox default: inherit, not forced.**
+   Takopi does not inject a sandbox mode — the user's `~/.codex/config.toml` and Codex profile settings are respected. `/tools codex` shows the current state as "inherited from codex config" when no override is set. Users opt into `workspace-write` explicitly via `/tools codex sandbox write` when they want write-capable runs from Telegram. This avoids silently overriding stricter existing setups.

--- a/src/takopi/model.py
+++ b/src/takopi/model.py
@@ -17,6 +17,7 @@ type ActionKind = Literal[
     "turn",
     "warning",
     "telemetry",
+    "prompt",
 ]
 
 type TakopiEventType = Literal[

--- a/src/takopi/progress.py
+++ b/src/takopi/progress.py
@@ -41,7 +41,7 @@ class ProgressTracker:
                 self.resume = resume
                 return True
             case ActionEvent(action=action, phase=phase, ok=ok):
-                if action.kind == "turn":
+                if action.kind in ("turn", "prompt"):
                     return False
                 action_id = str(action.id or "")
                 if not action_id:

--- a/src/takopi/runner.py
+++ b/src/takopi/runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import re
 import subprocess
@@ -349,6 +350,15 @@ class JsonlSubprocessRunner(BaseRunner):
             raise RuntimeError(message)
         return found_session, False
 
+    def keep_stdin_open(self, *, state: Any) -> bool:
+        return False
+
+    def set_stdin_stream(self, state: Any, stream: Any) -> None:
+        pass
+
+    async def flush_stdin_writes(self, *, state: Any) -> None:
+        pass
+
     async def _send_payload(
         self,
         proc: Any,
@@ -356,11 +366,15 @@ class JsonlSubprocessRunner(BaseRunner):
         *,
         logger: Any,
         resume: ResumeToken | None,
+        state: Any,
     ) -> None:
         if payload is not None:
             assert proc.stdin is not None
             await proc.stdin.send(payload)
-            await proc.stdin.aclose()
+            if not self.keep_stdin_open(state=state):
+                await proc.stdin.aclose()
+            else:
+                self.set_stdin_stream(state, proc.stdin)
             logger.info(
                 "subprocess.stdin.send",
                 pid=proc.pid,
@@ -368,7 +382,10 @@ class JsonlSubprocessRunner(BaseRunner):
                 bytes=len(payload),
             )
         elif proc.stdin is not None:
-            await proc.stdin.aclose()
+            if not self.keep_stdin_open(state=state):
+                await proc.stdin.aclose()
+            else:
+                self.set_stdin_stream(state, proc.stdin)
 
     def _decode_jsonl_events(
         self,
@@ -592,6 +609,7 @@ class JsonlSubprocessRunner(BaseRunner):
                 pid=pid,
             ):
                 yield evt
+            await self.flush_stdin_writes(state=state)
 
     async def run_impl(
         self, prompt: str, resume: ResumeToken | None
@@ -634,29 +652,37 @@ class JsonlSubprocessRunner(BaseRunner):
                 pid=proc.pid,
             )
 
-            await self._send_payload(proc, payload, logger=logger, resume=resume)
+            stdin_kept_open = self.keep_stdin_open(state=state)
+            await self._send_payload(
+                proc, payload, logger=logger, resume=resume, state=state
+            )
 
             rc: int | None = None
             stream = JsonlStreamState(expected_session=resume)
 
-            async with anyio.create_task_group() as tg:
-                tg.start_soon(
-                    drain_stderr,
-                    proc.stderr,
-                    logger,
-                    tag,
-                )
-                async for evt in self._iter_jsonl_events(
-                    stdout=proc.stdout,
-                    stream=stream,
-                    state=state,
-                    resume=resume,
-                    logger=logger,
-                    pid=proc.pid,
-                ):
-                    yield evt
+            try:
+                async with anyio.create_task_group() as tg:
+                    tg.start_soon(
+                        drain_stderr,
+                        proc.stderr,
+                        logger,
+                        tag,
+                    )
+                    async for evt in self._iter_jsonl_events(
+                        stdout=proc.stdout,
+                        stream=stream,
+                        state=state,
+                        resume=resume,
+                        logger=logger,
+                        pid=proc.pid,
+                    ):
+                        yield evt
 
-                rc = await proc.wait()
+                    rc = await proc.wait()
+            finally:
+                if stdin_kept_open and proc.stdin is not None:
+                    with contextlib.suppress(Exception):
+                        await proc.stdin.aclose()
 
             logger.info("subprocess.exit", pid=proc.pid, rc=rc)
             if stream.did_emit_completed:

--- a/src/takopi/runner.py
+++ b/src/takopi/runner.py
@@ -610,6 +610,8 @@ class JsonlSubprocessRunner(BaseRunner):
             ):
                 yield evt
             await self.flush_stdin_writes(state=state)
+            if stream.did_emit_completed:
+                break
 
     async def run_impl(
         self, prompt: str, resume: ResumeToken | None
@@ -678,6 +680,8 @@ class JsonlSubprocessRunner(BaseRunner):
                     ):
                         yield evt
 
+                    if stdin_kept_open and proc.stdin is not None:
+                        await proc.stdin.aclose()
                     rc = await proc.wait()
             finally:
                 if stdin_kept_open and proc.stdin is not None:

--- a/src/takopi/runner_bridge.py
+++ b/src/takopi/runner_bridge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -8,7 +9,7 @@ import anyio
 
 from .context import RunContext
 from .logging import bind_run_context, get_logger
-from .model import CompletedEvent, ResumeToken, StartedEvent, TakopiEvent
+from .model import ActionEvent, CompletedEvent, ResumeToken, StartedEvent, TakopiEvent
 from .presenter import Presenter
 from .markdown import render_event_cli
 from .runner import Runner
@@ -94,6 +95,13 @@ class RunningTask:
     cancel_requested: anyio.Event = field(default_factory=anyio.Event)
     done: anyio.Event = field(default_factory=anyio.Event)
     context: RunContext | None = None
+    prompt_seq: int = 0
+    pending_prompts: dict[str, anyio.Event] = field(default_factory=dict)
+    prompt_responses: dict[str, dict[str, object] | None] = field(default_factory=dict)
+    prompt_responders: dict[str, Callable[[dict[str, object]], Awaitable[None]]] = field(
+        default_factory=dict
+    )
+    prompt_messages: dict[str, MessageRef] = field(default_factory=dict)
 
 
 RunningTasks = dict[MessageRef, RunningTask]
@@ -165,6 +173,9 @@ class ProgressEdits:
         resume_formatter: Callable[[ResumeToken], str] | None = None,
         label: str = "working",
         context_line: str | None = None,
+        running_task: RunningTask | None = None,
+        prompt_markup_fn: Callable[..., dict] | None = None,
+        format_prompt_fn: Callable[[str, dict], str] | None = None,
     ) -> None:
         self.transport = transport
         self.presenter = presenter
@@ -180,6 +191,9 @@ class ProgressEdits:
         self.event_seq = 0
         self.rendered_seq = 0
         self.signal_send, self.signal_recv = anyio.create_memory_object_stream(1)
+        self._running_task = running_task
+        self._prompt_markup_fn = prompt_markup_fn
+        self._format_prompt_fn = format_prompt_fn
 
     async def run(self) -> None:
         if self.progress_ref is None:
@@ -218,6 +232,15 @@ class ProgressEdits:
             self.rendered_seq = seq_at_render
 
     async def on_event(self, evt: TakopiEvent) -> None:
+        if (
+            isinstance(evt, ActionEvent)
+            and evt.action.kind == "prompt"
+            and self._running_task is not None
+            and self.progress_ref is not None
+        ):
+            await self._handle_prompt_event(evt)
+            return
+
         if not self.tracker.note_event(evt):
             return
         if self.progress_ref is None:
@@ -229,6 +252,40 @@ class ProgressEdits:
             pass
         except (anyio.BrokenResourceError, anyio.ClosedResourceError):
             pass
+
+    async def _handle_prompt_event(self, evt: ActionEvent) -> None:
+        task = self._running_task
+        if task is None or self.progress_ref is None:
+            return
+        detail = evt.action.detail
+        local_id = detail.get("local_id", "")
+        tool_name = detail.get("tool_name", "tool")
+        tool_input = detail.get("input", {})
+        permission_suggestions = detail.get("permission_suggestions")
+
+        if self._format_prompt_fn is not None:
+            text = self._format_prompt_fn(tool_name, tool_input)
+        else:
+            text = f"Permission requested: {tool_name}"
+
+        extra: dict[str, object] = {}
+        if self._prompt_markup_fn is not None:
+            extra["reply_markup"] = self._prompt_markup_fn(
+                local_id,
+                permission_suggestions,
+                progress_msg_id=self.progress_ref.message_id,
+            )
+
+        sent = await self.transport.send(
+            channel_id=self.channel_id,
+            message=RenderedMessage(text=text, extra=extra),
+            options=SendOptions(
+                reply_to=self.progress_ref,
+                notify=True,
+            ),
+        )
+        if sent is not None and local_id:
+            task.prompt_messages[local_id] = sent
 
 
 @dataclass(frozen=True, slots=True)
@@ -291,6 +348,62 @@ class RunOutcome:
     resume: ResumeToken | None = None
 
 
+PROMPT_TIMEOUT_S = 300.0
+
+
+async def _wait_prompt_response(
+    running_task: RunningTask,
+    local_id: str,
+    timeout_s: float,
+    transport: Transport | None = None,
+) -> None:
+    timed_out = False
+    try:
+        with anyio.fail_after(timeout_s):
+            await running_task.pending_prompts[local_id].wait()
+    except TimeoutError:
+        timed_out = True
+
+    try:
+        if timed_out:
+            if transport is not None:
+                prompt_ref = running_task.prompt_messages.get(local_id)
+                if prompt_ref is not None:
+                    with contextlib.suppress(Exception):
+                        await transport.edit(
+                            ref=prompt_ref,
+                            message=RenderedMessage(
+                                text="timed out",
+                                extra={"reply_markup": {"inline_keyboard": []}},
+                            ),
+                        )
+            responder = running_task.prompt_responders.get(local_id)
+            if responder is not None:
+                with contextlib.suppress(Exception):
+                    await responder({"error": "timed out"})
+            return
+
+        response = running_task.prompt_responses.get(local_id)
+        responder = running_task.prompt_responders.get(local_id)
+        if responder is not None and response is not None:
+            allowed = response.get("allowed", False)
+            if allowed:
+                payload: dict[str, object] = {"allowed": True}
+            else:
+                payload = {"error": "denied by user"}
+            with contextlib.suppress(Exception):
+                await responder(payload)
+    finally:
+        _cleanup_prompt(running_task, local_id)
+
+
+def _cleanup_prompt(running_task: RunningTask, local_id: str) -> None:
+    running_task.pending_prompts.pop(local_id, None)
+    running_task.prompt_responses.pop(local_id, None)
+    running_task.prompt_responders.pop(local_id, None)
+    running_task.prompt_messages.pop(local_id, None)
+
+
 async def run_runner_with_cancel(
     runner: Runner,
     *,
@@ -299,6 +412,7 @@ async def run_runner_with_cancel(
     edits: ProgressEdits,
     running_task: RunningTask | None,
     on_thread_known: Callable[[ResumeToken, anyio.Event], Awaitable[None]] | None,
+    prompt_timeout_s: float = PROMPT_TIMEOUT_S,
 ) -> RunOutcome:
     outcome = RunOutcome()
     async with anyio.create_task_group() as tg:
@@ -320,6 +434,27 @@ async def run_runner_with_cancel(
                     elif isinstance(evt, CompletedEvent):
                         outcome.resume = evt.resume or outcome.resume
                         outcome.completed = evt
+                    elif (
+                        isinstance(evt, ActionEvent)
+                        and evt.action.kind == "prompt"
+                        and running_task is not None
+                    ):
+                        request_id = evt.action.detail.get("request_id")
+                        respond_fn = evt.action.detail.pop("_respond", None)
+                        if request_id is not None:
+                            running_task.prompt_seq += 1
+                            local_id = f"p{running_task.prompt_seq}"
+                            evt.action.detail["local_id"] = local_id
+                            running_task.pending_prompts[local_id] = anyio.Event()
+                            if respond_fn is not None:
+                                running_task.prompt_responders[local_id] = respond_fn
+                            tg.start_soon(
+                                _wait_prompt_response,
+                                running_task,
+                                local_id,
+                                prompt_timeout_s,
+                                edits.transport,
+                            )
                     await edits.on_event(evt)
             finally:
                 tg.cancel_scope.cancel()
@@ -397,6 +532,8 @@ async def handle_message(
     | None = None,
     progress_ref: MessageRef | None = None,
     clock: Callable[[], float] = time.monotonic,
+    prompt_markup_fn: Callable[..., dict] | None = None,
+    format_prompt_fn: Callable[[str, dict], str] | None = None,
 ) -> None:
     logger.info(
         "handle.incoming",
@@ -440,12 +577,15 @@ async def handle_message(
         last_rendered=progress_state.last_rendered,
         resume_formatter=runner.format_resume,
         context_line=context_line,
+        prompt_markup_fn=prompt_markup_fn,
+        format_prompt_fn=format_prompt_fn,
     )
 
     running_task: RunningTask | None = None
     if running_tasks is not None and progress_ref is not None:
         running_task = RunningTask(context=context)
         running_tasks[progress_ref] = running_task
+        edits._running_task = running_task
 
     cancel_exc_type = anyio.get_cancelled_exc_class()
     edits_scope = anyio.CancelScope()
@@ -526,6 +666,16 @@ async def handle_message(
         return
 
     if outcome.cancelled:
+        if running_task is not None:
+            for prompt_ref in running_task.prompt_messages.values():
+                with contextlib.suppress(Exception):
+                    await cfg.transport.edit(
+                        ref=prompt_ref,
+                        message=RenderedMessage(
+                            text="cancelled",
+                            extra={"reply_markup": {"inline_keyboard": []}},
+                        ),
+                    )
         resume = sync_resume_token(progress_tracker, outcome.resume)
         logger.info(
             "handle.cancelled",

--- a/src/takopi/runner_bridge.py
+++ b/src/takopi/runner_bridge.py
@@ -437,24 +437,28 @@ async def run_runner_with_cancel(
                     elif (
                         isinstance(evt, ActionEvent)
                         and evt.action.kind == "prompt"
-                        and running_task is not None
                     ):
-                        request_id = evt.action.detail.get("request_id")
                         respond_fn = evt.action.detail.pop("_respond", None)
-                        if request_id is not None:
-                            running_task.prompt_seq += 1
-                            local_id = f"p{running_task.prompt_seq}"
-                            evt.action.detail["local_id"] = local_id
-                            running_task.pending_prompts[local_id] = anyio.Event()
-                            if respond_fn is not None:
-                                running_task.prompt_responders[local_id] = respond_fn
-                            tg.start_soon(
-                                _wait_prompt_response,
-                                running_task,
-                                local_id,
-                                prompt_timeout_s,
-                                edits.transport,
-                            )
+                        if running_task is not None:
+                            request_id = evt.action.detail.get("request_id")
+                            if request_id is not None:
+                                running_task.prompt_seq += 1
+                                local_id = f"p{running_task.prompt_seq}"
+                                evt.action.detail["local_id"] = local_id
+                                running_task.pending_prompts[local_id] = anyio.Event()
+                                if respond_fn is not None:
+                                    running_task.prompt_responders[local_id] = respond_fn
+                                tg.start_soon(
+                                    _wait_prompt_response,
+                                    running_task,
+                                    local_id,
+                                    prompt_timeout_s,
+                                    edits.transport,
+                                )
+                        elif respond_fn is not None:
+                            logger.warning("prompt.no_task", detail=evt.action.detail)
+                            with contextlib.suppress(Exception):
+                                await respond_fn({"error": "no interactive session"})
                     await edits.on_event(evt)
             finally:
                 tg.cancel_scope.cancel()

--- a/src/takopi/runners/claude.py
+++ b/src/takopi/runners/claude.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
 from dataclasses import dataclass, field
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
 
+import anyio
 import msgspec
 
 from ..backends import EngineBackend, EngineConfig
@@ -34,6 +37,9 @@ class ClaudeStreamState:
     pending_actions: dict[str, Action] = field(default_factory=dict)
     last_assistant_text: str | None = None
     note_seq: int = 0
+    stdin_stream: anyio.abc.ByteStream | None = None
+    stdin_lock: anyio.Lock = field(default_factory=anyio.Lock)
+    pending_stdin_writes: list[bytes] = field(default_factory=list)
 
 
 def _normalize_tool_result(content: Any) -> str:
@@ -274,7 +280,95 @@ def translate_claude_event(
                     usage=usage or None,
                 )
             ]
+        case claude_schema.StreamControlRequest(
+            request_id=request_id, request=request
+        ):
+            return _handle_control_request(
+                request_id, request, state=state, factory=factory
+            )
         case _:
+            return []
+
+
+def _make_respond_callable(
+    state: ClaudeStreamState,
+    request_id: str,
+) -> Callable[[dict[str, Any]], Awaitable[None]]:
+    """Return a closure that accepts a simple dict and writes the
+    Claude-encoded control response to stdin.
+
+    The bridge layer passes either ``{"allowed": True}``,
+    ``{"error": "denied by user"}``, or ``{"error": "timed out"}``.
+    Encoding is handled here so the bridge stays engine-agnostic.
+    """
+
+    async def _respond(payload: dict[str, Any]) -> None:
+        error = payload.get("error")
+        if error is not None:
+            data = claude_schema.encode_control_response(
+                request_id, error=error
+            )
+        else:
+            data = claude_schema.encode_control_response(
+                request_id, response=payload
+            )
+        async with state.stdin_lock:
+            stream = state.stdin_stream
+            if stream is not None:
+                await stream.send(data)
+
+    return _respond
+
+
+def _handle_control_request(
+    request_id: str,
+    request: claude_schema.ControlRequest,
+    *,
+    state: ClaudeStreamState,
+    factory: EventFactory,
+) -> list[TakopiEvent]:
+    match request:
+        case claude_schema.ControlCanUseToolRequest(
+            tool_name=tool_name,
+            input=tool_input,
+            permission_suggestions=permission_suggestions,
+        ):
+            state.note_seq += 1
+            action_id = f"claude.prompt.{state.note_seq}"
+            input_preview = json.dumps(tool_input, ensure_ascii=False)
+            if len(input_preview) > 200:
+                input_preview = input_preview[:200] + "…"
+            detail: dict[str, Any] = {
+                "request_id": request_id,
+                "request_type": "can_use_tool",
+                "tool_name": tool_name,
+                "input": tool_input,
+                "input_preview": input_preview,
+                "permission_suggestions": permission_suggestions,
+                "_respond": _make_respond_callable(state, request_id),
+            }
+            return [
+                factory.action(
+                    phase="started",
+                    action_id=action_id,
+                    kind="prompt",
+                    title=f"Permission: {tool_name}",
+                    detail=detail,
+                )
+            ]
+        case claude_schema.ControlInitializeRequest():
+            resp = claude_schema.encode_control_response(request_id, response={})
+            state.pending_stdin_writes.append(resp)
+            return []
+        case claude_schema.ControlSetPermissionModeRequest():
+            resp = claude_schema.encode_control_response(request_id, response={})
+            state.pending_stdin_writes.append(resp)
+            return []
+        case _:
+            resp = claude_schema.encode_control_response(
+                request_id, error="not supported"
+            )
+            state.pending_stdin_writes.append(resp)
             return []
 
 
@@ -298,7 +392,14 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
 
     def _build_args(self, prompt: str, resume: ResumeToken | None) -> list[str]:
         run_options = get_run_options()
-        args: list[str] = ["-p", "--output-format", "stream-json", "--verbose"]
+        args: list[str] = [
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--input-format",
+            "stream-json",
+            "--verbose",
+        ]
         if resume is not None:
             args.extend(["--resume", resume.value])
         model = self.model
@@ -311,8 +412,6 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             args.extend(["--allowedTools", allowed_tools])
         if self.dangerously_skip_permissions is True:
             args.append("--dangerously-skip-permissions")
-        args.append("--")
-        args.append(prompt)
         return args
 
     def command(self) -> str:
@@ -334,7 +433,38 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         *,
         state: Any,
     ) -> bytes | None:
-        return None
+        message = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": prompt}],
+            },
+        }
+        return json.dumps(message).encode() + b"\n"
+
+    def keep_stdin_open(self, *, state: Any) -> bool:
+        return True
+
+    def set_stdin_stream(self, state: Any, stream: Any) -> None:
+        if isinstance(state, ClaudeStreamState):
+            state.stdin_stream = stream
+
+    async def flush_stdin_writes(self, *, state: Any) -> None:
+        if not isinstance(state, ClaudeStreamState):
+            return
+        if not state.pending_stdin_writes:
+            return
+        async with state.stdin_lock:
+            stream = state.stdin_stream
+            if stream is None:
+                state.pending_stdin_writes.clear()
+                return
+            for data in state.pending_stdin_writes:
+                try:
+                    await stream.send(data)
+                except Exception:  # noqa: BLE001
+                    break
+            state.pending_stdin_writes.clear()
 
     def env(self, *, state: Any) -> dict[str, str] | None:
         if self.use_api_billing is not True:

--- a/src/takopi/schemas/claude.py
+++ b/src/takopi/schemas/claude.py
@@ -233,6 +233,22 @@ STREAM_JSON_SCHEMA = msgspec.json.schema(StreamJsonMessage)
 
 _DECODER = msgspec.json.Decoder(StreamJsonMessage)
 
+_RESPONSE_ENCODER = msgspec.json.Encoder()
+
 
 def decode_stream_json_line(line: str | bytes) -> StreamJsonMessage:
     return _DECODER.decode(line)
+
+
+def encode_control_response(
+    request_id: str,
+    *,
+    response: dict[str, Any] | None = None,
+    error: str | None = None,
+) -> bytes:
+    if error is not None:
+        inner = ControlErrorResponse(request_id=request_id, error=error)
+    else:
+        inner = ControlSuccessResponse(request_id=request_id, response=response)
+    msg = StreamControlResponse(response=inner)
+    return _RESPONSE_ENCODER.encode(msg) + b"\n"

--- a/src/takopi/telegram/bridge.py
+++ b/src/takopi/telegram/bridge.py
@@ -454,13 +454,12 @@ async def handle_callback_prompt(
         response["allowed"] = False
         feedback = "Denied"
 
+    prompt_msg_ref = running_task.prompt_messages.get(local_id)
+
     running_task.prompt_responses[local_id] = response
     running_task.pending_prompts[local_id].set()
 
     await cfg.bot.answer_callback_query(query.callback_query_id, text=feedback)
-
-    # Edit the prompt message to show the decision and remove buttons
-    prompt_msg_ref = running_task.prompt_messages.get(local_id)
     if prompt_msg_ref is not None:
         icon = "✓" if action == "allow" else "✗"
         await cfg.bot.edit_message_text(

--- a/src/takopi/telegram/bridge.py
+++ b/src/takopi/telegram/bridge.py
@@ -25,13 +25,17 @@ from .types import TelegramCallbackQuery, TelegramIncomingMessage
 logger = get_logger(__name__)
 
 __all__ = [
+    "PROMPT_CALLBACK_PREFIX",
     "TelegramBridgeConfig",
     "TelegramPresenter",
     "TelegramTransport",
     "build_bot_commands",
+    "format_prompt_text",
     "handle_callback_cancel",
+    "handle_callback_prompt",
     "handle_cancel",
     "is_cancel_command",
+    "prompt_markup",
     "run_main_loop",
     "send_with_resume",
 ]
@@ -41,6 +45,52 @@ CANCEL_MARKUP = {
     "inline_keyboard": [[{"text": "cancel", "callback_data": CANCEL_CALLBACK_DATA}]]
 }
 CLEAR_MARKUP = {"inline_keyboard": []}
+
+PROMPT_CALLBACK_PREFIX = "takopi:prompt:"
+
+# v1: only allow/deny. allow_always omitted until Claude's ControlSuccessResponse
+# shape for "always allow" is verified against the wire protocol.
+_KNOWN_ACTIONS: dict[str, str] = {
+    "allow": "Allow",
+    "deny": "Deny",
+}
+
+
+def prompt_markup(
+    local_id: str,
+    permission_suggestions: list[object] | None,
+    *,
+    progress_msg_id: object,
+) -> dict:
+    suggestions = ["allow", "deny"]
+    if permission_suggestions:
+        filtered = [str(s) for s in permission_suggestions if str(s) in _KNOWN_ACTIONS]
+        if filtered:
+            suggestions = filtered
+
+    buttons = []
+    for suggestion in suggestions:
+        label = _KNOWN_ACTIONS[suggestion]
+        cb = f"{PROMPT_CALLBACK_PREFIX}{progress_msg_id}:{local_id}:{suggestion}"
+        buttons.append({"text": label, "callback_data": cb})
+
+    return {"inline_keyboard": [buttons]}
+
+
+def format_prompt_text(tool_name: str, tool_input: dict) -> str:
+    parts = [f"Permission: {tool_name}"]
+    if tool_name == "Bash" and "command" in tool_input:
+        cmd = str(tool_input["command"])
+        if len(cmd) > 200:
+            cmd = cmd[:200] + "…"
+        parts.append(cmd)
+    elif tool_name in ("Read", "Write", "Edit"):
+        path = tool_input.get("file_path") or tool_input.get("path")
+        if path:
+            parts.append(str(path))
+    elif tool_name == "Glob" and "pattern" in tool_input:
+        parts.append(str(tool_input["pattern"]))
+    return "\n".join(parts)
 
 
 class TelegramPresenter:
@@ -357,6 +407,68 @@ async def handle_callback_cancel(
     from .commands import handle_callback_cancel as _handle_callback_cancel
 
     await _handle_callback_cancel(cfg, query, running_tasks, scheduler)
+
+
+async def handle_callback_prompt(
+    cfg: TelegramBridgeConfig,
+    query: TelegramCallbackQuery,
+    running_tasks: RunningTasks,
+) -> None:
+    data = query.data or ""
+    # Format: takopi:prompt:{progress_msg_id}:{local_id}:{action}
+    parts = data[len(PROMPT_CALLBACK_PREFIX) :].split(":", 2)
+    if len(parts) != 3:
+        await cfg.bot.answer_callback_query(query.callback_query_id, text="invalid")
+        return
+
+    progress_msg_id_str, local_id, action = parts
+    try:
+        progress_msg_id = int(progress_msg_id_str)
+    except ValueError:
+        await cfg.bot.answer_callback_query(query.callback_query_id, text="invalid")
+        return
+
+    ref = MessageRef(channel_id=query.chat_id, message_id=progress_msg_id)
+    running_task = running_tasks.get(ref)
+    if running_task is None:
+        await cfg.bot.answer_callback_query(
+            query.callback_query_id, text="session ended"
+        )
+        return
+
+    if local_id not in running_task.pending_prompts:
+        await cfg.bot.answer_callback_query(
+            query.callback_query_id, text="expired"
+        )
+        return
+
+    if action not in {"allow", "deny"}:
+        await cfg.bot.answer_callback_query(query.callback_query_id, text="invalid")
+        return
+
+    response: dict[str, object] = {}
+    if action == "allow":
+        response["allowed"] = True
+        feedback = "Allowed"
+    else:
+        response["allowed"] = False
+        feedback = "Denied"
+
+    running_task.prompt_responses[local_id] = response
+    running_task.pending_prompts[local_id].set()
+
+    await cfg.bot.answer_callback_query(query.callback_query_id, text=feedback)
+
+    # Edit the prompt message to show the decision and remove buttons
+    prompt_msg_ref = running_task.prompt_messages.get(local_id)
+    if prompt_msg_ref is not None:
+        icon = "✓" if action == "allow" else "✗"
+        await cfg.bot.edit_message_text(
+            chat_id=cast(int, prompt_msg_ref.channel_id),
+            message_id=cast(int, prompt_msg_ref.message_id),
+            text=f"{icon} {feedback}",
+            reply_markup=CLEAR_MARKUP,
+        )
 
 
 async def send_with_resume(

--- a/src/takopi/telegram/commands/executor.py
+++ b/src/takopi/telegram/commands/executor.py
@@ -26,7 +26,7 @@ from ...scheduler import ThreadScheduler
 from ...transport import MessageRef, RenderedMessage, SendOptions
 from ...transport_runtime import TransportRuntime
 from ...utils.paths import reset_run_base_dir, set_run_base_dir
-from ..bridge import send_plain
+from ..bridge import format_prompt_text, prompt_markup, send_plain
 from ..engine_overrides import supports_reasoning
 
 logger = get_logger(__name__)
@@ -233,6 +233,8 @@ async def _run_engine(
                     running_tasks=running_tasks,
                     on_thread_known=on_thread_known,
                     progress_ref=progress_ref,
+                    prompt_markup_fn=prompt_markup,
+                    format_prompt_fn=format_prompt_text,
                 )
         finally:
             reset_run_base_dir(run_base_token)

--- a/src/takopi/telegram/loop.py
+++ b/src/takopi/telegram/loop.py
@@ -24,7 +24,13 @@ from ..transport import MessageRef, SendOptions
 from ..transport_runtime import ResolvedMessage
 from ..context import RunContext
 from ..ids import RESERVED_CHAT_COMMANDS
-from .bridge import CANCEL_CALLBACK_DATA, TelegramBridgeConfig, send_plain
+from .bridge import (
+    CANCEL_CALLBACK_DATA,
+    PROMPT_CALLBACK_PREFIX,
+    TelegramBridgeConfig,
+    handle_callback_prompt,
+    send_plain,
+)
 from .commands.cancel import handle_callback_cancel, handle_cancel
 from .commands.file_transfer import FILE_PUT_USAGE
 from .commands.handlers import (
@@ -1838,6 +1844,15 @@ async def run_main_loop(
                             update,
                             state.running_tasks,
                             scheduler,
+                        )
+                    elif update.data and update.data.startswith(
+                        PROMPT_CALLBACK_PREFIX
+                    ):
+                        tg.start_soon(
+                            handle_callback_prompt,
+                            cfg,
+                            update,
+                            state.running_tasks,
                         )
                     else:
                         tg.start_soon(

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -6,7 +6,8 @@ import anyio
 import pytest
 
 import takopi.runners.claude as claude_runner
-from takopi.model import ActionEvent, CompletedEvent, ResumeToken, StartedEvent
+from takopi.model import Action, ActionEvent, CompletedEvent, ResumeToken, StartedEvent
+from takopi.progress import ProgressTracker
 from takopi.runners.claude import (
     ClaudeRunner,
     ClaudeStreamState,
@@ -423,3 +424,260 @@ async def test_run_strips_anthropic_api_key_by_default(tmp_path, monkeypatch) ->
         if isinstance(event, CompletedEvent):
             answer = event.answer
     assert answer == "api=set"
+
+
+
+def _make_control_request(
+    subtype: str,
+    request_id: str = "req-1",
+    **extra: object,
+) -> claude_schema.StreamControlRequest:
+    payload: dict = {
+        "type": "control_request",
+        "request_id": request_id,
+        "request": {"subtype": subtype, **extra},
+    }
+    data = json.dumps(payload).encode()
+    return cast(
+        claude_schema.StreamControlRequest,
+        claude_schema.decode_stream_json_line(data),
+    )
+
+
+def test_translate_control_can_use_tool() -> None:
+    state = ClaudeStreamState()
+    event = _make_control_request(
+        "can_use_tool",
+        request_id="req-42",
+        tool_name="Bash",
+        input={"command": "echo hello"},
+        permission_suggestions=["allow", "deny"],
+    )
+    events = translate_claude_event(
+        event, title="claude", state=state, factory=state.factory
+    )
+
+    assert len(events) == 1
+    evt = events[0]
+    assert isinstance(evt, ActionEvent)
+    assert evt.action.kind == "prompt"
+    assert evt.phase == "started"
+    assert evt.action.title == "Permission: Bash"
+    detail = evt.action.detail
+    assert detail["request_id"] == "req-42"
+    assert detail["request_type"] == "can_use_tool"
+    assert detail["tool_name"] == "Bash"
+    assert detail["input"] == {"command": "echo hello"}
+    assert detail["permission_suggestions"] == ["allow", "deny"]
+    assert callable(detail["_respond"])
+    assert not state.pending_stdin_writes
+
+
+@pytest.mark.anyio
+async def test_respond_callable_writes_to_stdin() -> None:
+    """Exercise the _respond closure end-to-end: translate a ControlCanUseToolRequest,
+    extract _respond, call it, and verify the correct bytes land on stdin_stream."""
+    state = ClaudeStreamState()
+
+    class RecordingStream:
+        def __init__(self) -> None:
+            self.written: list[bytes] = []
+
+        async def send(self, data: bytes) -> None:
+            self.written.append(data)
+
+    stream = RecordingStream()
+    state.stdin_stream = stream  # type: ignore[assignment]
+
+    event = _make_control_request(
+        "can_use_tool",
+        request_id="req-99",
+        tool_name="Bash",
+        input={"command": "rm -rf /"},
+        permission_suggestions=["allow", "deny"],
+    )
+    events = translate_claude_event(
+        event, title="claude", state=state, factory=state.factory
+    )
+    assert len(events) == 1
+    respond = events[0].action.detail["_respond"]
+
+    # Call with an "allowed" payload
+    await respond({"allowed": True})
+
+    assert len(stream.written) == 1
+    parsed = json.loads(stream.written[0])
+    assert parsed["type"] == "control_response"
+    assert parsed["response"]["subtype"] == "success"
+    assert parsed["response"]["request_id"] == "req-99"
+    assert parsed["response"]["response"] == {"allowed": True}
+
+    # Call with an error payload
+    await respond({"error": "denied by user"})
+
+    assert len(stream.written) == 2
+    parsed_err = json.loads(stream.written[1])
+    assert parsed_err["type"] == "control_response"
+    assert parsed_err["response"]["subtype"] == "error"
+    assert parsed_err["response"]["request_id"] == "req-99"
+    assert parsed_err["response"]["error"] == "denied by user"
+
+
+@pytest.mark.anyio
+async def test_respond_callable_noop_when_stream_is_none() -> None:
+    """If stdin_stream is None (process exited), _respond must not raise."""
+    state = ClaudeStreamState()
+    state.stdin_stream = None
+
+    event = _make_control_request(
+        "can_use_tool",
+        request_id="req-gone",
+        tool_name="Read",
+        input={"file_path": "/etc/passwd"},
+        permission_suggestions=[],
+    )
+    events = translate_claude_event(
+        event, title="claude", state=state, factory=state.factory
+    )
+    respond = events[0].action.detail["_respond"]
+
+    # Should complete without error even though there is no stream
+    await respond({"allowed": True})
+
+
+def test_translate_control_initialize_queues_auto_response() -> None:
+    state = ClaudeStreamState()
+    event = _make_control_request("initialize", request_id="req-init")
+    events = translate_claude_event(
+        event, title="claude", state=state, factory=state.factory
+    )
+
+    assert events == []
+    assert len(state.pending_stdin_writes) == 1
+    resp = json.loads(state.pending_stdin_writes[0])
+    assert resp["type"] == "control_response"
+    assert resp["response"]["subtype"] == "success"
+    assert resp["response"]["request_id"] == "req-init"
+
+
+def test_translate_control_set_permission_mode_queues_auto_response() -> None:
+    state = ClaudeStreamState()
+    event = _make_control_request(
+        "set_permission_mode", request_id="req-perm", mode="default"
+    )
+    events = translate_claude_event(
+        event, title="claude", state=state, factory=state.factory
+    )
+
+    assert events == []
+    assert len(state.pending_stdin_writes) == 1
+    resp = json.loads(state.pending_stdin_writes[0])
+    assert resp["response"]["subtype"] == "success"
+    assert resp["response"]["request_id"] == "req-perm"
+
+
+def test_translate_control_unsupported_queues_error_response() -> None:
+    state = ClaudeStreamState()
+    event = _make_control_request("interrupt", request_id="req-int")
+    events = translate_claude_event(
+        event, title="claude", state=state, factory=state.factory
+    )
+
+    assert events == []
+    assert len(state.pending_stdin_writes) == 1
+    resp = json.loads(state.pending_stdin_writes[0])
+    assert resp["response"]["subtype"] == "error"
+    assert resp["response"]["request_id"] == "req-int"
+    assert resp["response"]["error"] == "not supported"
+
+
+def test_encode_control_response_success() -> None:
+    data = claude_schema.encode_control_response("r1", response={"allowed": True})
+    parsed = json.loads(data)
+    assert parsed["type"] == "control_response"
+    assert parsed["response"]["subtype"] == "success"
+    assert parsed["response"]["request_id"] == "r1"
+    assert parsed["response"]["response"] == {"allowed": True}
+    assert data.endswith(b"\n")
+
+
+def test_encode_control_response_error() -> None:
+    data = claude_schema.encode_control_response("r2", error="not supported")
+    parsed = json.loads(data)
+    assert parsed["type"] == "control_response"
+    assert parsed["response"]["subtype"] == "error"
+    assert parsed["response"]["request_id"] == "r2"
+    assert parsed["response"]["error"] == "not supported"
+
+
+def test_stdin_payload_shape() -> None:
+    runner = ClaudeRunner(claude_cmd="claude")
+    state = runner.new_state("hello world", None)
+    payload = runner.stdin_payload("hello world", None, state=state)
+    assert payload is not None
+    parsed = json.loads(payload)
+    assert parsed["type"] == "user"
+    assert parsed["message"]["role"] == "user"
+    assert parsed["message"]["content"] == [{"type": "text", "text": "hello world"}]
+    assert payload.endswith(b"\n")
+
+
+def test_build_args_uses_stream_json_input() -> None:
+    runner = ClaudeRunner(claude_cmd="claude")
+    args = runner._build_args("test", None)
+    assert "--input-format" in args
+    idx = args.index("--input-format")
+    assert args[idx + 1] == "stream-json"
+    assert "--" not in args
+
+
+def test_keep_stdin_open() -> None:
+    runner = ClaudeRunner(claude_cmd="claude")
+    state = runner.new_state("test", None)
+    assert runner.keep_stdin_open(state=state) is True
+
+
+@pytest.mark.anyio
+async def test_flush_stdin_writes() -> None:
+    state = ClaudeStreamState()
+
+    class FakeStream:
+        def __init__(self) -> None:
+            self.written: list[bytes] = []
+
+        async def send(self, data: bytes) -> None:
+            self.written.append(data)
+
+    stream = FakeStream()
+    state.stdin_stream = stream  # type: ignore[assignment]
+    state.pending_stdin_writes = [b"line1\n", b"line2\n"]
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    await runner.flush_stdin_writes(state=state)
+
+    assert stream.written == [b"line1\n", b"line2\n"]
+    assert state.pending_stdin_writes == []
+
+
+@pytest.mark.anyio
+async def test_flush_stdin_writes_clears_on_no_stream() -> None:
+    state = ClaudeStreamState()
+    state.stdin_stream = None
+    state.pending_stdin_writes = [b"orphan\n"]
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    await runner.flush_stdin_writes(state=state)
+
+    assert state.pending_stdin_writes == []
+
+
+def test_progress_tracker_filters_prompt_kind() -> None:
+    tracker = ProgressTracker(engine="claude")
+    evt = ActionEvent(
+        engine="claude",
+        action=Action(id="prompt.1", kind="prompt", title="Permission: Bash"),
+        phase="started",
+    )
+    result = tracker.note_event(evt)
+    assert result is False
+    assert tracker.action_count == 0

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -426,6 +426,61 @@ async def test_run_strips_anthropic_api_key_by_default(tmp_path, monkeypatch) ->
     assert answer == "api=set"
 
 
+@pytest.mark.anyio
+async def test_run_closes_stdin_after_completed_event(tmp_path) -> None:
+    claude_path = tmp_path / "claude"
+    claude_path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json\n"
+        "import sys\n"
+        "\n"
+        "session_id = 'session_01'\n"
+        "payload = sys.stdin.readline()\n"
+        "assert payload\n"
+        "init = {\n"
+        "    'type': 'system',\n"
+        "    'subtype': 'init',\n"
+        "    'uuid': 'uuid',\n"
+        "    'session_id': session_id,\n"
+        "    'apiKeySource': 'env',\n"
+        "    'cwd': '.',\n"
+        "    'tools': [],\n"
+        "    'mcp_servers': [],\n"
+        "    'model': 'claude',\n"
+        "    'permissionMode': 'default',\n"
+        "    'slash_commands': [],\n"
+        "    'output_style': 'default',\n"
+        "}\n"
+        "print(json.dumps(init), flush=True)\n"
+        "result = {\n"
+        "    'type': 'result',\n"
+        "    'subtype': 'success',\n"
+        "    'uuid': 'uuid-result',\n"
+        "    'session_id': session_id,\n"
+        "    'duration_ms': 0,\n"
+        "    'duration_api_ms': 0,\n"
+        "    'is_error': False,\n"
+        "    'num_turns': 1,\n"
+        "    'result': 'done',\n"
+        "    'total_cost_usd': 0.0,\n"
+        "    'usage': {'input_tokens': 0, 'output_tokens': 0},\n"
+        "}\n"
+        "print(json.dumps(result), flush=True)\n"
+        "sys.stdin.read()\n",
+        encoding="utf-8",
+    )
+    claude_path.chmod(0o755)
+
+    runner = ClaudeRunner(claude_cmd=str(claude_path))
+    answer: str | None = None
+
+    with anyio.fail_after(2):
+        async for event in runner.run("hello", None):
+            if isinstance(event, CompletedEvent):
+                answer = event.answer
+
+    assert answer == "done"
+
 
 def _make_control_request(
     subtype: str,

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -5,7 +5,7 @@ import pytest
 
 from takopi.runner_bridge import ExecBridgeConfig, IncomingMessage, handle_message
 from takopi.markdown import MarkdownParts, MarkdownPresenter
-from takopi.model import ResumeToken, TakopiEvent
+from takopi.model import Action, ActionEvent, ResumeToken, TakopiEvent
 from takopi.telegram.render import prepare_telegram
 from takopi.runners.codex import CodexRunner
 from takopi.runners.mock import Advance, Emit, Raise, Return, ScriptRunner, Wait
@@ -411,6 +411,84 @@ async def test_handle_message_cancelled_renders_cancelled_state() -> None:
     last_edit = transport.edit_calls[-1]["message"].text
     assert "cancelled" in last_edit.lower()
     assert session_id in last_edit
+
+
+@pytest.mark.anyio
+async def test_handle_message_cancelled_cleans_up_prompt_messages() -> None:
+    transport = FakeTransport()
+    session_id = "019b66fc-64c2-7a71-81cd-081c504cfeb2"
+    hold = anyio.Event()
+    prompt_event = ActionEvent(
+        engine=CODEX_ENGINE,
+        action=Action(
+            id="req-1",
+            kind="prompt",
+            title="Permission: Bash",
+            detail={
+                "request_id": "req-1",
+                "request_type": "can_use_tool",
+                "tool_name": "Bash",
+                "input": {"command": "echo hi"},
+                "permission_suggestions": None,
+            },
+        ),
+        phase="started",
+    )
+    runner = ScriptRunner(
+        [Emit(prompt_event), Wait(hold)],
+        engine=CODEX_ENGINE,
+        resume_value=session_id,
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport,
+        presenter=MarkdownPresenter(),
+        final_notify=True,
+    )
+    running_tasks: dict = {}
+
+    def _format_prompt(tool_name: str, tool_input: dict) -> str:
+        return f"Permission: {tool_name}"
+
+    def _prompt_markup(local_id: str, suggestions: object, **kw: object) -> dict:
+        return {"inline_keyboard": [[{"text": "Allow", "callback_data": "x"}]]}
+
+    async def run_handle_message() -> None:
+        await handle_message(
+            cfg,
+            runner=runner,
+            incoming=IncomingMessage(
+                channel_id=123, message_id=10, text="do something"
+            ),
+            resume_token=None,
+            running_tasks=running_tasks,
+            prompt_markup_fn=_prompt_markup,
+            format_prompt_fn=_format_prompt,
+        )
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(run_handle_message)
+        for _ in range(100):
+            if running_tasks:
+                break
+            await anyio.sleep(0)
+        assert running_tasks
+        running_task = running_tasks[next(iter(running_tasks))]
+        with anyio.fail_after(1):
+            await running_task.resume_ready.wait()
+        # Wait for prompt message to be sent
+        for _ in range(100):
+            if running_task.prompt_messages:
+                break
+            await anyio.sleep(0)
+        running_task.cancel_requested.set()
+
+    # Find the prompt message edit (should say "cancelled" with cleared markup)
+    prompt_edits = [
+        e for e in transport.edit_calls
+        if e["message"].extra.get("reply_markup") == {"inline_keyboard": []}
+        and "cancelled" in e["message"].text.lower()
+    ]
+    assert len(prompt_edits) >= 1
 
 
 @pytest.mark.anyio

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -492,6 +492,51 @@ async def test_handle_message_cancelled_cleans_up_prompt_messages() -> None:
 
 
 @pytest.mark.anyio
+async def test_handle_message_prompt_auto_denied_without_running_tasks() -> None:
+    transport = FakeTransport()
+    session_id = "019b66fc-64c2-7a71-81cd-081c504cfeb2"
+    denied: list[dict] = []
+
+    async def fake_respond(payload: dict) -> None:
+        denied.append(payload)
+
+    prompt_event = ActionEvent(
+        engine=CODEX_ENGINE,
+        action=Action(
+            id="req-1",
+            kind="prompt",
+            title="Permission: Bash",
+            detail={
+                "request_id": "req-1",
+                "_respond": fake_respond,
+            },
+        ),
+        phase="started",
+    )
+    runner = ScriptRunner(
+        [Emit(prompt_event)],
+        engine=CODEX_ENGINE,
+        resume_value=session_id,
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport,
+        presenter=MarkdownPresenter(),
+        final_notify=True,
+    )
+
+    await handle_message(
+        cfg,
+        runner=runner,
+        incoming=IncomingMessage(channel_id=123, message_id=10, text="do something"),
+        resume_token=None,
+        running_tasks=None,
+    )
+
+    assert len(denied) == 1
+    assert "error" in denied[0]
+
+
+@pytest.mark.anyio
 async def test_handle_message_error_preserves_resume_token() -> None:
     transport = FakeTransport()
     session_id = "019b66fc-64c2-7a71-81cd-081c504cfeb2"

--- a/tests/test_prompt_bridge.py
+++ b/tests/test_prompt_bridge.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+from typing import cast
+
+import anyio
+import pytest
+
+from takopi.runner_bridge import RunningTask, _cleanup_prompt, _wait_prompt_response
+from takopi.telegram.bridge import (
+    PROMPT_CALLBACK_PREFIX,
+    format_prompt_text,
+    handle_callback_prompt,
+    prompt_markup,
+)
+from takopi.telegram.types import TelegramCallbackQuery
+from takopi.transport import MessageRef
+from tests.telegram_fakes import FakeBot, FakeTransport, make_cfg
+
+
+
+def test_prompt_markup_default_buttons() -> None:
+    mk = prompt_markup("p1", None, progress_msg_id=42)
+    buttons = mk["inline_keyboard"][0]
+    assert len(buttons) == 2
+    assert buttons[0]["text"] == "Allow"
+    assert buttons[1]["text"] == "Deny"
+    assert "p1:allow" in buttons[0]["callback_data"]
+    assert "p1:deny" in buttons[1]["callback_data"]
+
+
+def test_prompt_markup_filters_unknown_suggestions() -> None:
+    mk = prompt_markup("p2", ["allow", "magic", "deny"], progress_msg_id=10)
+    buttons = mk["inline_keyboard"][0]
+    labels = [b["text"] for b in buttons]
+    assert labels == ["Allow", "Deny"]
+
+
+def test_prompt_markup_falls_back_when_all_unknown() -> None:
+    mk = prompt_markup("p3", ["foo", "bar"], progress_msg_id=10)
+    buttons = mk["inline_keyboard"][0]
+    labels = [b["text"] for b in buttons]
+    assert labels == ["Allow", "Deny"]
+
+
+def test_prompt_markup_empty_suggestions_gives_defaults() -> None:
+    mk = prompt_markup("p1", [], progress_msg_id=10)
+    buttons = mk["inline_keyboard"][0]
+    assert len(buttons) == 2
+
+
+def test_prompt_markup_callback_data_format() -> None:
+    mk = prompt_markup("p1", ["allow", "deny"], progress_msg_id=999)
+    buttons = mk["inline_keyboard"][0]
+    assert buttons[0]["callback_data"] == f"{PROMPT_CALLBACK_PREFIX}999:p1:allow"
+    assert buttons[1]["callback_data"] == f"{PROMPT_CALLBACK_PREFIX}999:p1:deny"
+
+
+def test_prompt_markup_callback_data_fits_telegram_limit() -> None:
+    mk = prompt_markup("p99", ["allow", "deny"], progress_msg_id=9999999999)
+    for button in mk["inline_keyboard"][0]:
+        assert len(button["callback_data"].encode()) <= 64
+
+
+
+def test_format_prompt_text_bash_command() -> None:
+    text = format_prompt_text("Bash", {"command": "echo hello"})
+    assert "Bash" in text
+    assert "echo hello" in text
+
+
+def test_format_prompt_text_bash_truncates_long_command() -> None:
+    long_cmd = "x" * 300
+    text = format_prompt_text("Bash", {"command": long_cmd})
+    assert len(text) < 300
+
+
+def test_format_prompt_text_read_shows_path() -> None:
+    text = format_prompt_text("Read", {"file_path": "/tmp/foo.py"})
+    assert "/tmp/foo.py" in text
+
+
+def test_format_prompt_text_read_falls_back_to_path_key() -> None:
+    text = format_prompt_text("Read", {"path": "/tmp/bar.py"})
+    assert "/tmp/bar.py" in text
+
+
+def test_format_prompt_text_file_path_preferred_over_path() -> None:
+    text = format_prompt_text("Edit", {"file_path": "/a.py", "path": "/b.py"})
+    assert "/a.py" in text
+    assert "/b.py" not in text
+
+
+def test_format_prompt_text_write_no_path_keys() -> None:
+    text = format_prompt_text("Write", {"content": "hello"})
+    assert "Write" in text
+    assert "\n" not in text  # only the header line
+
+
+def test_format_prompt_text_glob_shows_pattern() -> None:
+    text = format_prompt_text("Glob", {"pattern": "**/*.py"})
+    assert "**/*.py" in text
+
+
+def test_format_prompt_text_unknown_tool() -> None:
+    text = format_prompt_text("CustomTool", {"arg": "val"})
+    assert "CustomTool" in text
+
+
+
+def _make_query(
+    *,
+    chat_id: int = 123,
+    progress_msg_id: int = 42,
+    local_id: str = "p1",
+    action: str = "allow",
+) -> TelegramCallbackQuery:
+    data = f"{PROMPT_CALLBACK_PREFIX}{progress_msg_id}:{local_id}:{action}"
+    return TelegramCallbackQuery(
+        transport="telegram",
+        chat_id=chat_id,
+        message_id=progress_msg_id,
+        callback_query_id="cbq-1",
+        data=data,
+        sender_id=chat_id,
+    )
+
+
+def _make_task_with_prompt(
+    local_id: str = "p1",
+) -> RunningTask:
+    task = RunningTask()
+    task.pending_prompts[local_id] = anyio.Event()
+    task.prompt_messages[local_id] = MessageRef(channel_id=123, message_id=99)
+    return task
+
+
+@pytest.mark.anyio
+async def test_handle_callback_prompt_allow() -> None:
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+    task = _make_task_with_prompt()
+    ref = MessageRef(channel_id=123, message_id=42)
+    running_tasks = {ref: task}
+
+    query = _make_query(action="allow")
+    await handle_callback_prompt(cfg, query, running_tasks)
+
+    assert task.pending_prompts["p1"].is_set()
+    assert task.prompt_responses["p1"]["allowed"] is True
+    bot = cast(FakeBot, cfg.bot)
+    assert bot.callback_calls[-1]["text"] == "Allowed"
+
+
+@pytest.mark.anyio
+async def test_handle_callback_prompt_deny() -> None:
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+    task = _make_task_with_prompt()
+    ref = MessageRef(channel_id=123, message_id=42)
+    running_tasks = {ref: task}
+
+    query = _make_query(action="deny")
+    await handle_callback_prompt(cfg, query, running_tasks)
+
+    assert task.prompt_responses["p1"]["allowed"] is False
+    bot = cast(FakeBot, cfg.bot)
+    assert bot.callback_calls[-1]["text"] == "Denied"
+
+
+@pytest.mark.anyio
+async def test_handle_callback_prompt_unknown_action_rejected_as_invalid() -> None:
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+    task = _make_task_with_prompt()
+    ref = MessageRef(channel_id=123, message_id=42)
+    running_tasks = {ref: task}
+
+    query = _make_query(action="something_else")
+    await handle_callback_prompt(cfg, query, running_tasks)
+
+    bot = cast(FakeBot, cfg.bot)
+    assert bot.callback_calls[-1]["text"] == "invalid"
+    assert not task.pending_prompts["p1"].is_set()
+    assert "p1" not in task.prompt_responses
+
+
+@pytest.mark.anyio
+async def test_handle_callback_prompt_no_task_says_session_ended() -> None:
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+
+    query = _make_query()
+    await handle_callback_prompt(cfg, query, {})
+
+    bot = cast(FakeBot, cfg.bot)
+    assert bot.callback_calls[-1]["text"] == "session ended"
+
+
+@pytest.mark.anyio
+async def test_handle_callback_prompt_expired_prompt() -> None:
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+    task = RunningTask()  # no pending prompts
+    ref = MessageRef(channel_id=123, message_id=42)
+    running_tasks = {ref: task}
+
+    query = _make_query()
+    await handle_callback_prompt(cfg, query, running_tasks)
+
+    bot = cast(FakeBot, cfg.bot)
+    assert bot.callback_calls[-1]["text"] == "expired"
+
+
+@pytest.mark.anyio
+async def test_handle_callback_prompt_invalid_data() -> None:
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+    query = TelegramCallbackQuery(
+        transport="telegram",
+        chat_id=123,
+        message_id=1,
+        callback_query_id="cbq-bad",
+        data=f"{PROMPT_CALLBACK_PREFIX}not-enough-parts",
+        sender_id=123,
+    )
+
+    await handle_callback_prompt(cfg, query, {})
+
+    bot = cast(FakeBot, cfg.bot)
+    assert bot.callback_calls[-1]["text"] == "invalid"
+
+
+@pytest.mark.anyio
+async def test_handle_callback_prompt_edits_prompt_message() -> None:
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+    task = _make_task_with_prompt()
+    ref = MessageRef(channel_id=123, message_id=42)
+    running_tasks = {ref: task}
+
+    query = _make_query(action="allow")
+    await handle_callback_prompt(cfg, query, running_tasks)
+
+    bot = cast(FakeBot, cfg.bot)
+    assert bot.edit_calls
+    edit = bot.edit_calls[-1]
+    assert edit["message_id"] == 99
+    assert "Allowed" in edit["text"]
+    assert edit["reply_markup"] is not None  # CLEAR_MARKUP
+
+
+@pytest.mark.anyio
+async def test_handle_callback_prompt_deny_edits_with_denied_icon() -> None:
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+    task = _make_task_with_prompt()
+    ref = MessageRef(channel_id=123, message_id=42)
+    running_tasks = {ref: task}
+
+    query = _make_query(action="deny")
+    await handle_callback_prompt(cfg, query, running_tasks)
+
+    bot = cast(FakeBot, cfg.bot)
+    assert bot.edit_calls
+    edit = bot.edit_calls[-1]
+    assert "Denied" in edit["text"]
+    assert "\u2713" not in edit["text"]  # no checkmark on deny
+
+
+
+@pytest.mark.anyio
+async def test_wait_prompt_response_allow() -> None:
+    task = RunningTask()
+    task.pending_prompts["p1"] = anyio.Event()
+    written: list[dict[str, object]] = []
+
+    async def fake_respond(data: dict[str, object]) -> None:
+        written.append(data)
+
+    task.prompt_responders["p1"] = fake_respond
+
+    # Simulate user response in a separate task
+    async with anyio.create_task_group() as tg:
+
+        async def respond_soon() -> None:
+            await anyio.sleep(0.01)
+            task.prompt_responses["p1"] = {"allowed": True}
+            task.pending_prompts["p1"].set()
+
+        tg.start_soon(respond_soon)
+        await _wait_prompt_response(task, "p1", timeout_s=5.0)
+
+    assert len(written) == 1
+    assert written[0] == {"allowed": True}
+    # cleanup happened
+    assert "p1" not in task.pending_prompts
+
+
+@pytest.mark.anyio
+async def test_wait_prompt_response_deny() -> None:
+    task = RunningTask()
+    task.pending_prompts["p1"] = anyio.Event()
+    written: list[dict[str, object]] = []
+
+    async def fake_respond(data: dict[str, object]) -> None:
+        written.append(data)
+
+    task.prompt_responders["p1"] = fake_respond
+
+    async with anyio.create_task_group() as tg:
+
+        async def respond_soon() -> None:
+            await anyio.sleep(0.01)
+            task.prompt_responses["p1"] = {"allowed": False}
+            task.pending_prompts["p1"].set()
+
+        tg.start_soon(respond_soon)
+        await _wait_prompt_response(task, "p1", timeout_s=5.0)
+
+    assert len(written) == 1
+    assert written[0] == {"error": "denied by user"}
+
+
+@pytest.mark.anyio
+async def test_wait_prompt_response_timeout() -> None:
+    task = RunningTask()
+    task.pending_prompts["p1"] = anyio.Event()
+    written: list[dict[str, object]] = []
+
+    async def fake_respond(data: dict[str, object]) -> None:
+        written.append(data)
+
+    task.prompt_responders["p1"] = fake_respond
+
+    await _wait_prompt_response(task, "p1", timeout_s=0.01)
+
+    assert len(written) == 1
+    assert written[0] == {"error": "timed out"}
+    # cleanup happened
+    assert "p1" not in task.pending_prompts
+
+
+@pytest.mark.anyio
+async def test_wait_prompt_response_timeout_edits_message() -> None:
+    transport = FakeTransport()
+    task = RunningTask()
+    task.pending_prompts["p1"] = anyio.Event()
+    prompt_ref = MessageRef(channel_id=123, message_id=99)
+    task.prompt_messages["p1"] = prompt_ref
+    written: list[dict[str, object]] = []
+
+    async def fake_respond(data: dict[str, object]) -> None:
+        written.append(data)
+
+    task.prompt_responders["p1"] = fake_respond
+
+    await _wait_prompt_response(task, "p1", timeout_s=0.01, transport=transport)
+
+    assert len(written) == 1
+    assert written[0] == {"error": "timed out"}
+    # prompt message was edited to clear buttons
+    assert len(transport.edit_calls) == 1
+    edit = transport.edit_calls[0]
+    assert edit["ref"] == prompt_ref
+    assert edit["message"].text == "timed out"
+    assert edit["message"].extra["reply_markup"] == {"inline_keyboard": []}
+    # cleanup happened
+    assert "p1" not in task.pending_prompts
+    assert "p1" not in task.prompt_messages
+
+
+@pytest.mark.anyio
+async def test_wait_prompt_response_cleans_up_on_completion() -> None:
+    task = RunningTask()
+    task.pending_prompts["p1"] = anyio.Event()
+    task.prompt_responders["p1"] = lambda _: None  # type: ignore[return-value, arg-type]
+
+    task.prompt_responses["p1"] = {"allowed": True}
+    task.pending_prompts["p1"].set()
+
+    await _wait_prompt_response(task, "p1", timeout_s=5.0)
+
+    assert "p1" not in task.pending_prompts
+    assert "p1" not in task.prompt_responses
+    assert "p1" not in task.prompt_responders
+
+
+
+def test_cleanup_prompt_removes_all_state() -> None:
+    task = RunningTask()
+    task.pending_prompts["p1"] = anyio.Event()
+    task.prompt_responses["p1"] = {"allowed": True}
+    task.prompt_messages["p1"] = MessageRef(channel_id=1, message_id=1)
+
+    _cleanup_prompt(task, "p1")
+
+    assert "p1" not in task.pending_prompts
+    assert "p1" not in task.prompt_responses
+    assert "p1" not in task.prompt_messages
+
+
+def test_cleanup_prompt_ignores_missing_keys() -> None:
+    task = RunningTask()
+    _cleanup_prompt(task, "p99")  # should not raise


### PR DESCRIPTION
> **Draft — investigation + groundwork only.** User-facing permission management is not complete yet. Phase A items (denial visibility, `/tools` command, config flags) are pending.

## Problem

Tool permission denials in takopi are invisible — users see cryptic errors or hanging sessions (#195). No way to manage `allowed_tools` or engine settings from Telegram.

## Investigation findings

- `-p` mode never emits `control_request` — Claude auto-denies unapproved tools internally
- `--permission-prompt-tool stdio` (Agent SDK protocol) has a [confirmed bug](https://github.com/anthropics/claude-agent-sdk-python/issues/469) — `can_use_tool` callbacks never fire (tested through CLI v2.1.73)
- `permission_denials` data exists in stream-json output but takopi's schema silently drops it
- Codex has no interactive approval in `exec --json` mode

## What's in this branch

Interactive prompt infrastructure for the `control_request` protocol:
- Bidirectional stdin protocol with `StreamControlRequest` handling
- Telegram inline buttons for tool approval with timeout + auto-deny
- Not user-effective today because Claude CLI does not emit approval requests on the `-p` path

## Planned (Phase A — this PR or follow-up)

- Surface `permission_denials` as warning events
- `/tools` command to manage allowed tools per engine from Telegram
- `permission_mode` config for Claude
- Codex sandbox/search/network settings
- Gate interactive protocol behind `control_protocol` config flag

Full design spec: [`docs/superpowers/specs/2026-03-21-permission-management-design.md`](docs/superpowers/specs/2026-03-21-permission-management-design.md)

Refs #195, #207