### PR TITLE
feat(runners): optional hcom wrapper for claude and codex

### DIFF
--- a/docs/how-to/switch-engines.md
+++ b/docs/how-to/switch-engines.md
@@ -36,6 +36,43 @@ Selection precedence (highest to lowest): resume token → `/<engine-id>` direct
 Takopi shells out to engine CLIs. Install them and make sure they’re on your `PATH`
 (`codex`, `claude`, `opencode`, `pi`). Authentication is handled by each CLI.
 
+## hcom wrapper
+
+[hcom](https://github.com/aannoo/hcom) is an inter-agent messaging layer that
+launches Claude/Codex with hooks for cross-terminal coordination. Takopi can
+spawn engines through `hcom` instead of running them directly.
+
+Enable per-engine in `takopi.toml`:
+
+```toml
+[claude]
+hcom = true
+hcom_args = ["--tag", "takopi"]   # optional: passed to hcom before "claude"
+
+[codex]
+hcom = true
+```
+
+Equivalent CLI form:
+
+```sh
+takopi config set claude.hcom true
+takopi config set claude.hcom_args '["--tag", "takopi"]'
+```
+
+When enabled, takopi runs `hcom [hcom_args] claude ...` (or `... codex ...`)
+in place of the bare CLI. Existing flags (`-p`, `--output-format stream-json`,
+`--resume`, `--model`, prompt, etc.) are forwarded unchanged.
+
+Default behavior is preserved — set `hcom = false` (or omit it) to keep
+takopi's existing direct-spawn invocation.
+
+!!! warning "Codex caveat"
+    Current hcom releases reject `codex exec`, which Takopi uses for streaming
+    runs. The `[codex] hcom` knob exists for parity, but until hcom supports
+    `exec` mode you'll see hcom's error when starting a codex run with the
+    wrapper enabled. Use Claude with hcom in the meantime.
+
 ## Related
 
 - [Commands & directives](../reference/commands-and-directives.md)

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -150,12 +150,16 @@ here; plugin engines should document their own keys.
 |-----|------|---------|-------|
 | `extra_args` | string[] | `["-c", "notify=[]"]` | Extra CLI args for `codex` (exec-only flags are rejected). |
 | `profile` | string | (unset) | Passed as `--profile <name>` and used as the session title. |
+| `hcom` | bool | `false` | Wrap invocations with [hcom](https://github.com/aannoo/hcom): spawns `hcom codex ...` instead of `codex ...`. |
+| `hcom_cmd` | string | `"hcom"` | Path or name of the hcom binary. |
+| `hcom_args` | string[] | `[]` | Args inserted between `hcom` and `codex` (e.g. `["--tag", "takopi"]`). |
 
 === "takopi config"
 
     ```sh
     takopi config set codex.extra_args '["-c", "notify=[]"]'
     takopi config set codex.profile "work"
+    takopi config set codex.hcom true
     ```
 
 === "toml"
@@ -164,7 +168,14 @@ here; plugin engines should document their own keys.
     [codex]
     extra_args = ["-c", "notify=[]"]
     profile = "work"
+    hcom = true
     ```
+
+!!! note "hcom and codex"
+    At the time of writing, `hcom codex` rejects codex's `exec` subcommand,
+    which Takopi uses for streaming runs. Until hcom supports `codex exec`, the
+    wrapper option is exposed for parity but Takopi will surface hcom's error
+    when the codex backend tries to start. See [Switch engines](../how-to/switch-engines.md#hcom-wrapper).
 
 ### `claude`
 
@@ -174,6 +185,9 @@ here; plugin engines should document their own keys.
 | `allowed_tools` | string[] | `["Bash", "Read", "Edit", "Write"]` | Auto-approve tool rules. |
 | `dangerously_skip_permissions` | bool | `false` | Skip Claude permissions prompts. |
 | `use_api_billing` | bool | `false` | Keep `ANTHROPIC_API_KEY` for API billing. |
+| `hcom` | bool | `false` | Wrap invocations with [hcom](https://github.com/aannoo/hcom): spawns `hcom claude ...` instead of `claude ...`. |
+| `hcom_cmd` | string | `"hcom"` | Path or name of the hcom binary. |
+| `hcom_args` | string[] | `[]` | Args inserted between `hcom` and `claude` (e.g. `["--tag", "takopi"]`). |
 
 === "takopi config"
 
@@ -182,6 +196,8 @@ here; plugin engines should document their own keys.
     takopi config set claude.allowed_tools '["Bash", "Read", "Edit", "Write"]'
     takopi config set claude.dangerously_skip_permissions false
     takopi config set claude.use_api_billing false
+    takopi config set claude.hcom true
+    takopi config set claude.hcom_args '["--tag", "takopi"]'
     ```
 
 === "toml"
@@ -192,7 +208,15 @@ here; plugin engines should document their own keys.
     allowed_tools = ["Bash", "Read", "Edit", "Write"]
     dangerously_skip_permissions = false
     use_api_billing = false
+    hcom = true
+    hcom_args = ["--tag", "takopi"]
     ```
+
+When `hcom = true`, takopi spawns `hcom [hcom_args] claude ...` instead of
+`claude ...`. The trailing arguments (`-p --output-format stream-json --verbose`,
+`--resume`, `--model`, `--allowedTools`, the prompt, etc.) are forwarded
+unchanged so Claude still streams JSON the way Takopi expects. See
+[Switch engines](../how-to/switch-engines.md#hcom-wrapper).
 
 ### `pi`
 

--- a/src/takopi/runners/claude.py
+++ b/src/takopi/runners/claude.py
@@ -14,6 +14,7 @@ from ..events import EventFactory
 from ..logging import get_logger
 from ..model import Action, ActionKind, EngineId, ResumeToken, TakopiEvent
 from ..runner import JsonlSubprocessRunner, ResumeTokenMixin, Runner
+from .hcom_wrap import HCOM_DISABLED, HcomWrap, parse_hcom_config
 from .run_options import get_run_options
 from ..schemas import claude as claude_schema
 from .tool_actions import tool_input_path, tool_kind_and_title
@@ -289,6 +290,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
     dangerously_skip_permissions: bool = False
     use_api_billing: bool = False
     session_title: str = "claude"
+    hcom: HcomWrap = HCOM_DISABLED
     logger = logger
 
     def format_resume(self, token: ResumeToken) -> str:
@@ -316,7 +318,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         return args
 
     def command(self) -> str:
-        return self.claude_cmd
+        return self.hcom.wrap_command(self.claude_cmd)
 
     def build_args(
         self,
@@ -325,7 +327,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         *,
         state: Any,
     ) -> list[str]:
-        return self._build_args(prompt, resume)
+        return self.hcom.wrap_args(self.claude_cmd, self._build_args(prompt, resume))
 
     def stdin_payload(
         self,
@@ -454,7 +456,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         ]
 
 
-def build_runner(config: EngineConfig, _config_path: Path) -> Runner:
+def build_runner(config: EngineConfig, config_path: Path) -> Runner:
     claude_cmd = shutil.which("claude") or "claude"
 
     model = config.get("model")
@@ -466,6 +468,8 @@ def build_runner(config: EngineConfig, _config_path: Path) -> Runner:
     use_api_billing = config.get("use_api_billing") is True
     title = str(model) if model is not None else "claude"
 
+    hcom = parse_hcom_config(config, config_path=config_path, section="claude")
+
     return ClaudeRunner(
         claude_cmd=claude_cmd,
         model=model,
@@ -473,6 +477,7 @@ def build_runner(config: EngineConfig, _config_path: Path) -> Runner:
         dangerously_skip_permissions=dangerously_skip_permissions,
         use_api_billing=use_api_billing,
         session_title=title,
+        hcom=hcom,
     )
 
 

--- a/src/takopi/runners/codex.py
+++ b/src/takopi/runners/codex.py
@@ -13,6 +13,7 @@ from ..events import EventFactory
 from ..logging import get_logger
 from ..model import ActionPhase, EngineId, ResumeToken, TakopiEvent
 from ..runner import JsonlSubprocessRunner, ResumeTokenMixin, Runner
+from .hcom_wrap import HCOM_DISABLED, HcomWrap, parse_hcom_config
 from .run_options import get_run_options
 from ..schemas import codex as codex_schema
 from ..utils.paths import relativize_command
@@ -456,13 +457,15 @@ class CodexRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         codex_cmd: str,
         extra_args: list[str],
         title: str = "Codex",
+        hcom: HcomWrap = HCOM_DISABLED,
     ) -> None:
         self.codex_cmd = codex_cmd
         self.extra_args = extra_args
         self.session_title = title
+        self.hcom = hcom
 
     def command(self) -> str:
-        return self.codex_cmd
+        return self.hcom.wrap_command(self.codex_cmd)
 
     def build_args(
         self,
@@ -495,7 +498,7 @@ class CodexRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             args.extend(["resume", resume.value, "-"])
         else:
             args.append("-")
-        return args
+        return self.hcom.wrap_args(self.codex_cmd, args)
 
     def new_state(self, prompt: str, resume: ResumeToken | None) -> CodexRunState:
         return CodexRunState(factory=EventFactory(ENGINE))
@@ -695,7 +698,14 @@ def build_runner(config: EngineConfig, config_path: Path) -> Runner:
         extra_args.extend(["--profile", profile_value])
         title = profile_value
 
-    return CodexRunner(codex_cmd=codex_cmd, extra_args=extra_args, title=title)
+    hcom = parse_hcom_config(config, config_path=config_path, section="codex")
+
+    return CodexRunner(
+        codex_cmd=codex_cmd,
+        extra_args=extra_args,
+        title=title,
+        hcom=hcom,
+    )
 
 
 BACKEND = EngineBackend(

--- a/src/takopi/runners/hcom_wrap.py
+++ b/src/takopi/runners/hcom_wrap.py
@@ -1,0 +1,107 @@
+"""Shared helpers for wrapping engine CLIs with `hcom`.
+
+When ``hcom`` is enabled in an engine's config, takopi spawns
+``hcom [hcom_args...] <engine> [engine_args...]`` instead of ``<engine>
+[engine_args...]``. This lets users plug into the
+[hcom](https://github.com/aannoo/hcom) inter-agent messaging layer without
+changing the engine binary itself.
+
+The behavior is intentionally minimal: takopi treats hcom as a transparent
+prefix and forwards the existing engine arguments unchanged. If hcom does not
+support a particular engine subcommand or flag combination (for example, codex
+``exec`` mode), the underlying error surfaces through the normal subprocess
+output.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..config import ConfigError
+
+
+@dataclass(frozen=True, slots=True)
+class HcomWrap:
+    """Configured invocation prefix for `hcom <engine> ...`."""
+
+    enabled: bool
+    cmd: str
+    args: tuple[str, ...]
+
+    def wrap_command(self, engine_cmd: str) -> str:
+        """Return the program to spawn (`hcom` or the original engine cmd)."""
+        if not self.enabled:
+            return engine_cmd
+        return self.cmd
+
+    def wrap_args(
+        self,
+        engine_cmd: str,
+        engine_args: list[str],
+    ) -> list[str]:
+        """Return the argv tail to pass to the wrapped command.
+
+        When disabled, returns ``engine_args`` unchanged. When enabled, returns
+        ``[*hcom_args, <engine-subcommand>, *engine_args]`` where the
+        engine-subcommand is the basename of ``engine_cmd``. This lets hcom's
+        argv parser see the canonical tool name (``claude``/``codex``) even if
+        the user pointed ``claude_cmd``/``codex_cmd`` at an absolute path.
+        """
+        if not self.enabled:
+            return list(engine_args)
+        engine_subcommand = Path(engine_cmd).name or engine_cmd
+        return [*self.args, engine_subcommand, *engine_args]
+
+
+HCOM_DISABLED = HcomWrap(enabled=False, cmd="hcom", args=())
+
+
+def parse_hcom_config(
+    config: dict[str, Any],
+    *,
+    config_path: Path,
+    section: str,
+) -> HcomWrap:
+    """Parse ``[<section>] hcom*`` keys into an :class:`HcomWrap`.
+
+    Recognized keys:
+
+    - ``hcom`` (bool, default ``false``): enable the wrapper.
+    - ``hcom_cmd`` (string, default ``"hcom"``): path/name of the hcom binary.
+    - ``hcom_args`` (list[str], default ``[]``): extra args inserted between
+      ``hcom`` and the engine subcommand (e.g. ``["--tag", "takopi"]``).
+    """
+    enabled_value = config.get("hcom", False)
+    if not isinstance(enabled_value, bool):
+        raise ConfigError(
+            f"Invalid `{section}.hcom` in {config_path}; expected a boolean."
+        )
+
+    cmd_value = config.get("hcom_cmd", "hcom")
+    if not isinstance(cmd_value, str) or not cmd_value:
+        raise ConfigError(
+            f"Invalid `{section}.hcom_cmd` in {config_path}; "
+            "expected a non-empty string."
+        )
+
+    args_value = config.get("hcom_args", [])
+    if args_value is None:
+        args_tuple: tuple[str, ...] = ()
+    elif isinstance(args_value, list) and all(
+        isinstance(item, str) for item in args_value
+    ):
+        args_tuple = tuple(args_value)
+    else:
+        raise ConfigError(
+            f"Invalid `{section}.hcom_args` in {config_path}; "
+            "expected a list of strings."
+        )
+
+    if not enabled_value:
+        return HcomWrap(enabled=False, cmd=cmd_value, args=args_tuple)
+
+    resolved = shutil.which(cmd_value) or cmd_value
+    return HcomWrap(enabled=True, cmd=resolved, args=args_tuple)

--- a/tests/test_hcom_wrapper.py
+++ b/tests/test_hcom_wrapper.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from takopi.config import ConfigError
+from takopi.runners import claude as claude_runner
+from takopi.runners import codex as codex_runner
+from takopi.runners.hcom_wrap import (
+    HCOM_DISABLED,
+    HcomWrap,
+    parse_hcom_config,
+)
+
+
+def test_hcom_disabled_returns_engine_command_unchanged() -> None:
+    wrap = HCOM_DISABLED
+    assert wrap.wrap_command("/usr/bin/claude") == "/usr/bin/claude"
+    assert wrap.wrap_args(
+        "/usr/bin/claude", ["-p", "--output-format", "stream-json"]
+    ) == ["-p", "--output-format", "stream-json"]
+
+
+def test_hcom_enabled_prepends_engine_subcommand() -> None:
+    wrap = HcomWrap(enabled=True, cmd="/usr/local/bin/hcom", args=("--tag", "takopi"))
+    assert wrap.wrap_command("/usr/bin/claude") == "/usr/local/bin/hcom"
+    assert wrap.wrap_args(
+        "/usr/bin/claude",
+        ["-p", "--output-format", "stream-json", "--", "hi"],
+    ) == [
+        "--tag",
+        "takopi",
+        "claude",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--",
+        "hi",
+    ]
+
+
+def test_hcom_enabled_uses_basename_when_engine_cmd_is_absolute_path(
+    tmp_path: Path,
+) -> None:
+    wrap = HcomWrap(enabled=True, cmd="hcom", args=())
+    fake_codex = tmp_path / "codex"
+    assert wrap.wrap_args(str(fake_codex), ["exec"]) == ["codex", "exec"]
+
+
+def test_parse_hcom_config_defaults_disabled(tmp_path: Path) -> None:
+    wrap = parse_hcom_config({}, config_path=tmp_path / "takopi.toml", section="claude")
+    assert wrap.enabled is False
+    assert wrap.cmd == "hcom"
+    assert wrap.args == ()
+
+
+def test_parse_hcom_config_resolves_binary_when_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "takopi.runners.hcom_wrap.shutil.which",
+        lambda name: f"/opt/bin/{name}" if name == "hcom" else None,
+    )
+    wrap = parse_hcom_config(
+        {"hcom": True, "hcom_args": ["--tag", "takopi"]},
+        config_path=tmp_path / "takopi.toml",
+        section="claude",
+    )
+    assert wrap.enabled is True
+    assert wrap.cmd == "/opt/bin/hcom"
+    assert wrap.args == ("--tag", "takopi")
+
+
+def test_parse_hcom_config_keeps_literal_cmd_when_not_on_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("takopi.runners.hcom_wrap.shutil.which", lambda name: None)
+    wrap = parse_hcom_config(
+        {"hcom": True, "hcom_cmd": "hcom"},
+        config_path=tmp_path / "takopi.toml",
+        section="codex",
+    )
+    assert wrap.enabled is True
+    assert wrap.cmd == "hcom"
+
+
+def test_parse_hcom_config_rejects_non_bool_enable(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError):
+        parse_hcom_config(
+            {"hcom": "yes"},
+            config_path=tmp_path / "takopi.toml",
+            section="claude",
+        )
+
+
+def test_parse_hcom_config_rejects_empty_cmd(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError):
+        parse_hcom_config(
+            {"hcom_cmd": ""},
+            config_path=tmp_path / "takopi.toml",
+            section="claude",
+        )
+
+
+def test_parse_hcom_config_rejects_non_string_args(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError):
+        parse_hcom_config(
+            {"hcom_args": ["--tag", 1]},
+            config_path=tmp_path / "takopi.toml",
+            section="claude",
+        )
+
+
+def test_claude_build_runner_disables_hcom_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(claude_runner.shutil, "which", lambda name: f"/opt/bin/{name}")
+    runner = claude_runner.build_runner({}, tmp_path / "takopi.toml")
+    assert isinstance(runner, claude_runner.ClaudeRunner)
+    assert runner.hcom.enabled is False
+    assert runner.command() == "/opt/bin/claude"
+    args = runner.build_args("hello", None, state=None)
+    assert args[-1] == "hello"
+    assert "--output-format" in args
+    assert "stream-json" in args
+
+
+def test_claude_build_runner_wraps_with_hcom_when_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_which(name: str) -> str:
+        return f"/opt/bin/{name}"
+
+    monkeypatch.setattr(claude_runner.shutil, "which", fake_which)
+    monkeypatch.setattr("takopi.runners.hcom_wrap.shutil.which", fake_which)
+
+    runner = claude_runner.build_runner(
+        {"hcom": True, "hcom_args": ["--tag", "takopi"]},
+        tmp_path / "takopi.toml",
+    )
+    assert isinstance(runner, claude_runner.ClaudeRunner)
+    assert runner.hcom.enabled is True
+
+    assert runner.command() == "/opt/bin/hcom"
+    args = runner.build_args("hello", None, state=None)
+    assert args[:3] == ["--tag", "takopi", "claude"]
+    assert "--output-format" in args
+    assert args[-1] == "hello"
+
+
+def test_codex_build_runner_disables_hcom_by_default(tmp_path: Path) -> None:
+    runner = codex_runner.build_runner({}, tmp_path / "takopi.toml")
+    assert isinstance(runner, codex_runner.CodexRunner)
+    assert runner.hcom.enabled is False
+    assert runner.command() == "codex"
+    args = runner.build_args("hi", None, state=None)
+    assert "exec" in args
+    assert "--json" in args
+
+
+def test_codex_build_runner_wraps_with_hcom_when_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "takopi.runners.hcom_wrap.shutil.which",
+        lambda name: f"/opt/bin/{name}" if name == "hcom" else None,
+    )
+
+    runner = codex_runner.build_runner(
+        {"hcom": True, "hcom_args": ["--tag", "takopi"]},
+        tmp_path / "takopi.toml",
+    )
+    assert isinstance(runner, codex_runner.CodexRunner)
+    assert runner.hcom.enabled is True
+
+    assert runner.command() == "/opt/bin/hcom"
+    args = runner.build_args("hi", None, state=None)
+    assert args[:3] == ["--tag", "takopi", "codex"]
+    assert "exec" in args
+    assert "--json" in args
+
+
+def test_codex_build_runner_rejects_invalid_hcom_args(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError):
+        codex_runner.build_runner(
+            {"hcom": True, "hcom_args": "not-a-list"},
+            tmp_path / "takopi.toml",
+        )
+
+
+def test_claude_build_runner_rejects_invalid_hcom_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(claude_runner.shutil, "which", lambda name: f"/opt/bin/{name}")
+    with pytest.raises(ConfigError):
+        claude_runner.build_runner({"hcom": 1}, tmp_path / "takopi.toml")


### PR DESCRIPTION
## Summary

- Adds an opt-in [hcom](https://github.com/aannoo/hcom) integration to the
  `claude` and `codex` engines so takopi can run agents through hcom for
  cross-terminal coordination, hooks, and inter-agent messaging.
- Default behavior is preserved: `hcom` defaults to `false` on both engines.
  When enabled, takopi spawns `hcom [hcom_args] <engine> ...` instead of the
  bare CLI, and forwards every existing flag (`-p`, `--output-format
  stream-json`, `--verbose`, `--resume`, the prompt, …) unchanged.
- New TOML keys, mirrored on each engine:

  ```toml
  [claude]
  hcom = true
  hcom_cmd = "hcom"
  hcom_args = ["--tag", "takopi"]
  ```

  CLI form: `takopi config set claude.hcom true`. Env override:
  `TAKOPI__CLAUDE__HCOM=true` (works through pydantic-settings nested env).

- Implementation lives in a small shared helper at
  `src/takopi/runners/hcom_wrap.py` and is wired through the existing
  `command()` / `build_args()` hooks of `ClaudeRunner` and `CodexRunner`.
- Docs updated in `docs/reference/config.md` and
  `docs/how-to/switch-engines.md`.

### Caveat: codex + hcom

At the time of writing, `hcom codex` rejects codex's `exec` subcommand
(`Codex exec mode not supported in hcom.`), which takopi requires for
streaming runs. The codex knob is exposed for parity, but until upstream
hcom supports `codex exec` you'll see hcom's error when the codex backend
tries to start. The Claude path works end-to-end because hcom's claude
launcher already understands `-p`, `--output-format stream-json`,
`--verbose`, and `--resume`.

## Test plan

- [x] `uv run pytest` — 578 passed, 82.16% coverage.
- [x] `uv run ruff format --check src tests` — pass.
- [x] `uv run ruff check src tests` — pass.
- [x] `uv run ty check src tests` — only pre-existing diagnostics in
      unrelated telegram tests/loop; no new findings.
- [x] New `tests/test_hcom_wrapper.py` covers the helper, the parser
      (defaults / valid / invalid inputs), and verifies both runners'
      `build_runner` / `command` / `build_args` with and without hcom.
- [ ] Manual end-to-end run against a live `hcom` binary — not exercised in
      CI (requires hcom + claude install); the unit tests assert the
      argv shape that `hcom claude -p ...` expects.