### PR TITLE
fix: show resume line on queued telegram messages

### DIFF
--- a/src/takopi/telegram/loop.py
+++ b/src/takopi/telegram/loop.py
@@ -865,7 +865,20 @@ async def _send_queued_progress(
     tracker = ProgressTracker(engine=resume_token.engine)
     tracker.set_resume(resume_token)
     context_line = cfg.runtime.format_context_line(context)
-    state = tracker.snapshot(context_line=context_line)
+    resume_formatter = None
+    if should_show_resume_line(
+        show_resume_line=cfg.show_resume_line,
+        stateful_mode=cfg.session_mode == "chat",
+        context=context,
+    ):
+        resume_formatter = cfg.runtime.resolve_runner(
+            resume_token=resume_token,
+            engine_override=None,
+        ).runner.format_resume
+    state = tracker.snapshot(
+        resume_formatter=resume_formatter,
+        context_line=context_line,
+    )
     message = cfg.exec_cfg.presenter.render_progress(
         state,
         elapsed_s=0.0,

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -1470,7 +1470,9 @@ async def test_send_with_resume_waits_for_token() -> None:
     )
     assert sent[0][7] == transport.send_calls[0]["ref"]
     assert transport.send_calls
-    assert "queued" in transport.send_calls[0]["message"].text.lower()
+    queued_text = transport.send_calls[0]["message"].text.lower()
+    assert "queued" in queued_text
+    assert "codex resume abc123" in queued_text
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- render queued Telegram progress placeholders with the resolved runner resume formatter
- keep existing show_resume_line semantics for stateful chat mode
- add a regression assertion for queued continuation messages

## Tests
- uv run pytest tests/test_telegram_bridge.py::test_send_with_resume_waits_for_token -q --no-cov
- uv run pytest tests/test_telegram_bridge.py -q --no-cov
- uv run ruff format --check src/takopi/telegram/loop.py tests/test_telegram_bridge.py
- uv run ruff check src/takopi/telegram/loop.py tests/test_telegram_bridge.py