### PR TITLE
fix: show resume lines on resumed progress states

### DIFF
--- a/src/takopi/runner_bridge.py
+++ b/src/takopi/runner_bridge.py
@@ -411,6 +411,7 @@ async def handle_message(
     runner_text = _strip_resume_lines(incoming.text, is_resume_line=resume_strip)
 
     progress_tracker = ProgressTracker(engine=runner.engine)
+    progress_tracker.set_resume(resume_token)
 
     user_ref = MessageRef(
         channel_id=incoming.channel_id,

--- a/src/takopi/telegram/commands/cancel.py
+++ b/src/takopi/telegram/commands/cancel.py
@@ -107,7 +107,16 @@ async def _edit_cancelled_message(
     tracker = ProgressTracker(engine=job.resume_token.engine)
     tracker.set_resume(job.resume_token)
     context_line = cfg.runtime.format_context_line(job.context)
-    state = tracker.snapshot(context_line=context_line)
+    resume_formatter = None
+    if cfg.show_resume_line or cfg.session_mode != "chat":
+        resume_formatter = cfg.runtime.resolve_runner(
+            resume_token=job.resume_token,
+            engine_override=None,
+        ).runner.format_resume
+    state = tracker.snapshot(
+        resume_formatter=resume_formatter,
+        context_line=context_line,
+    )
     message = cfg.exec_cfg.presenter.render_progress(
         state,
         elapsed_s=0.0,

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -225,6 +225,7 @@ async def test_handle_message_strips_resume_line_from_prompt() -> None:
     prompt, passed_resume = runner.calls[0]
     assert prompt == "do this\nand that"
     assert passed_resume == resume
+    assert "codex resume sid" in transport.send_calls[0]["message"].text
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -657,7 +657,9 @@ async def test_handle_cancel_cancels_queued_job() -> None:
     await handle_cancel(cfg, msg, {}, scheduler)
 
     assert transport.edit_calls
-    assert "cancelled" in transport.edit_calls[0]["message"].text.lower()
+    cancelled_text = transport.edit_calls[0]["message"].text.lower()
+    assert "cancelled" in cancelled_text
+    assert "codex resume sid" in cancelled_text
     assert await scheduler.cancel_queued(123, progress_ref.message_id) is None
 
 
@@ -845,7 +847,9 @@ async def test_handle_callback_cancel_cancels_queued_job() -> None:
     await handle_callback_cancel(cfg, query, {}, scheduler)
 
     assert transport.edit_calls
-    assert "cancelled" in transport.edit_calls[0]["message"].text.lower()
+    cancelled_text = transport.edit_calls[0]["message"].text.lower()
+    assert "cancelled" in cancelled_text
+    assert "codex resume sid" in cancelled_text
     bot = cast(FakeBot, cfg.bot)
     assert bot.callback_calls
     assert bot.callback_calls[-1]["text"] == "dropped from queue."


### PR DESCRIPTION
## Summary
- seed progress tracking with known resume tokens before rendering initial resumed progress
- render resume lines on cancelled queued-job placeholders when resume lines are enabled
- add regression assertions for starting and queued-cancelled progress states

## Tests
- uv --no-config run --locked pytest tests/test_exec_bridge.py tests/test_telegram_bridge.py -q --no-cov
- uv --no-config run --locked ruff format --check src/takopi/runner_bridge.py src/takopi/telegram/commands/cancel.py tests/test_exec_bridge.py tests/test_telegram_bridge.py
- uv --no-config run --locked ruff check src/takopi/runner_bridge.py src/takopi/telegram/commands/cancel.py tests/test_exec_bridge.py tests/test_telegram_bridge.py
- uv --no-config run --locked pytest