### PR TITLE
feat: use codex app-server by default

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -148,12 +148,14 @@ here; plugin engines should document their own keys.
 
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
+| `mode` | `"app_server"`\|`"exec"` | `"app_server"` | Use `codex app-server` by default. Set `"exec"` for the legacy `codex exec --json` runner. |
 | `extra_args` | string[] | `["-c", "notify=[]"]` | Extra CLI args for `codex` (exec-only flags are rejected). |
 | `profile` | string | (unset) | Passed as `--profile <name>` and used as the session title. |
 
 === "takopi config"
 
     ```sh
+    takopi config set codex.mode "app_server"
     takopi config set codex.extra_args '["-c", "notify=[]"]'
     takopi config set codex.profile "work"
     ```
@@ -162,9 +164,15 @@ here; plugin engines should document their own keys.
 
     ```toml
     [codex]
+    mode = "app_server"
     extra_args = ["-c", "notify=[]"]
     profile = "work"
     ```
+
+`app_server` keeps one app-server child process per Takopi runner instance and
+uses `turn/interrupt` for cancel plus `turn/steer` for queued prompts on the
+same Codex thread. `exec` remains available for compatibility, but it cannot
+steer a running turn.
 
 ### `claude`
 

--- a/src/takopi/lockfile.py
+++ b/src/takopi/lockfile.py
@@ -154,5 +154,5 @@ def _display_lock_path(path: Path) -> str:
         resolved = path.expanduser().resolve()
         rel = resolved.relative_to(home)
         return f"~/{rel}"
-    except (ValueError, OSError):
+    except ValueError, OSError:
         return str(path)

--- a/src/takopi/logging.py
+++ b/src/takopi/logging.py
@@ -169,7 +169,7 @@ class SafeWriter(io.TextIOBase):
             return 0
         try:
             return self._stream.write(message)
-        except (BrokenPipeError, ValueError):
+        except BrokenPipeError, ValueError:
             self._close()
             return 0
         except OSError as exc:
@@ -183,7 +183,7 @@ class SafeWriter(io.TextIOBase):
             return
         try:
             self._stream.flush()
-        except (BrokenPipeError, ValueError):
+        except BrokenPipeError, ValueError:
             self._close()
         except OSError as exc:
             if exc.errno == errno.EPIPE:

--- a/src/takopi/plugins.py
+++ b/src/takopi/plugins.py
@@ -96,7 +96,7 @@ def entrypoint_distribution_name(ep: EntryPoint) -> str | None:
         return None
     try:
         return metadata["Name"]
-    except (KeyError, TypeError):
+    except KeyError, TypeError:
         return None
 
 

--- a/src/takopi/runner.py
+++ b/src/takopi/runner.py
@@ -710,3 +710,9 @@ class Runner(Protocol):
         prompt: str,
         resume: ResumeToken | None,
     ) -> AsyncIterator[TakopiEvent]: ...
+
+
+class RunnerTurnControl(Protocol):
+    async def steer(self, text: str) -> None: ...
+
+    async def interrupt(self) -> bool: ...

--- a/src/takopi/runner_bridge.py
+++ b/src/takopi/runner_bridge.py
@@ -228,7 +228,7 @@ class ProgressEdits:
             self.signal_send.send_nowait(None)
         except anyio.WouldBlock:
             pass
-        except (anyio.BrokenResourceError, anyio.ClosedResourceError):
+        except anyio.BrokenResourceError, anyio.ClosedResourceError:
             pass
 
 

--- a/src/takopi/runner_bridge.py
+++ b/src/takopi/runner_bridge.py
@@ -11,7 +11,7 @@ from .logging import bind_run_context, get_logger
 from .model import CompletedEvent, ResumeToken, StartedEvent, TakopiEvent
 from .presenter import Presenter
 from .markdown import render_event_cli
-from .runner import Runner
+from .runner import Runner, RunnerTurnControl
 from .progress import ProgressTracker
 from .transport import (
     ChannelId,
@@ -94,6 +94,7 @@ class RunningTask:
     cancel_requested: anyio.Event = field(default_factory=anyio.Event)
     done: anyio.Event = field(default_factory=anyio.Event)
     context: RunContext | None = None
+    control: RunnerTurnControl | None = None
 
 
 RunningTasks = dict[MessageRef, RunningTask]
@@ -312,6 +313,10 @@ async def run_runner_with_cancel(
                         bind_run_context(resume=evt.resume.value)
                         if running_task is not None and running_task.resume is None:
                             running_task.resume = evt.resume
+                            if evt.meta is not None:
+                                control = evt.meta.get("control")
+                                if control is not None:
+                                    running_task.control = control
                             try:
                                 if on_thread_known is not None:
                                     await on_thread_known(evt.resume, running_task.done)
@@ -326,6 +331,15 @@ async def run_runner_with_cancel(
 
         async def wait_cancel(task: RunningTask) -> None:
             await task.cancel_requested.wait()
+            if task.control is not None:
+                try:
+                    await task.control.interrupt()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "runner.control_interrupt_failed",
+                        error=str(exc),
+                        error_type=exc.__class__.__name__,
+                    )
             outcome.cancelled = True
             tg.cancel_scope.cancel()
 

--- a/src/takopi/runners/codex.py
+++ b/src/takopi/runners/codex.py
@@ -1328,6 +1328,7 @@ class AppServerCodexRunner(ResumeTokenMixin, BaseRunner):
                             done = True
                     if done:
                         return
+            raise RuntimeError("codex app-server closed before turn completed")
         finally:
             await client.unsubscribe_turn(turn_id)
 

--- a/src/takopi/runners/codex.py
+++ b/src/takopi/runners/codex.py
@@ -74,7 +74,7 @@ def _parse_reconnect_message(message: str) -> tuple[int, int] | None:
     try:
         attempt = int(match.group("attempt"))
         max_attempts = int(match.group("max"))
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
     return (attempt, max_attempts)
 
@@ -786,7 +786,9 @@ class _AppServerClient:
         async with self._state_lock:
             self._loaded_threads.add(thread_id)
 
-    async def turn_start(self, thread_id: str, params: dict[str, Any]) -> dict[str, Any]:
+    async def turn_start(
+        self, thread_id: str, params: dict[str, Any]
+    ) -> dict[str, Any]:
         payload = {"threadId": thread_id, **params}
         result = await self.request("turn/start", payload)
         if not isinstance(result, dict):
@@ -846,7 +848,9 @@ class _AppServerClient:
                 try:
                     message = json.loads(line.decode("utf-8"))
                 except json.JSONDecodeError as exc:
-                    raise RuntimeError(f"invalid JSON-RPC from codex app-server: {line!r}") from exc
+                    raise RuntimeError(
+                        f"invalid JSON-RPC from codex app-server: {line!r}"
+                    ) from exc
                 if not isinstance(message, dict):
                     continue
                 if "method" in message and "id" in message:
@@ -969,7 +973,11 @@ def _app_item_title(item: dict[str, Any]) -> str:
     if item_type == "fileChange":
         changes = item.get("changes")
         if isinstance(changes, list):
-            paths = [str(change.get("path")) for change in changes if isinstance(change, dict) and change.get("path")]
+            paths = [
+                str(change.get("path"))
+                for change in changes
+                if isinstance(change, dict) and change.get("path")
+            ]
             return ", ".join(paths) if paths else f"{len(changes)} files"
         return "files"
     if item_type == "webSearch":
@@ -1055,7 +1063,11 @@ def _translate_app_item_event(
         }
         title = _app_item_title(item)
         if phase == "started":
-            return [factory.action_started(action_id=item_id, kind="command", title=title, detail=detail)]
+            return [
+                factory.action_started(
+                    action_id=item_id, kind="command", title=title, detail=detail
+                )
+            ]
         ok = status == "completed"
         exit_code = item.get("exitCode")
         if isinstance(exit_code, int):
@@ -1083,7 +1095,11 @@ def _translate_app_item_event(
             detail["error_message"] = str(error.get("message") or error)
         title = _app_item_title(item)
         if phase == "started":
-            return [factory.action_started(action_id=item_id, kind="tool", title=title, detail=detail)]
+            return [
+                factory.action_started(
+                    action_id=item_id, kind="tool", title=title, detail=detail
+                )
+            ]
         return [
             factory.action_completed(
                 action_id=item_id,
@@ -1098,7 +1114,9 @@ def _translate_app_item_event(
         if phase != "completed":
             return []
         changes = item.get("changes")
-        normalized_changes = _normalize_change_list(changes if isinstance(changes, list) else [])
+        normalized_changes = _normalize_change_list(
+            changes if isinstance(changes, list) else []
+        )
         status = item.get("status")
         return [
             factory.action_completed(
@@ -1114,7 +1132,11 @@ def _translate_app_item_event(
         detail = {"query": item.get("query"), "action": item.get("action")}
         title = _app_item_title(item)
         if phase == "started":
-            return [factory.action_started(action_id=item_id, kind="web_search", title=title, detail=detail)]
+            return [
+                factory.action_started(
+                    action_id=item_id, kind="web_search", title=title, detail=detail
+                )
+            ]
         return [
             factory.action_completed(
                 action_id=item_id,
@@ -1304,7 +1326,9 @@ class AppServerCodexRunner(ResumeTokenMixin, BaseRunner):
         if not isinstance(turn, dict) or not isinstance(turn.get("id"), str):
             raise RuntimeError("turn/start returned no turn id")
         turn_id = turn["id"]
-        control = _AppServerTurnControl(client=client, thread_id=thread_id, turn_id=turn_id)
+        control = _AppServerTurnControl(
+            client=client, thread_id=thread_id, turn_id=turn_id
+        )
         yield EventFactory(ENGINE).started(
             token,
             title=self.session_title,

--- a/src/takopi/runners/codex.py
+++ b/src/takopi/runners/codex.py
@@ -834,10 +834,12 @@ class _AppServerClient:
             await self._proc.stdin.send(data)
 
     async def _reader_loop(self) -> None:
-        assert self._proc is not None
-        assert self._proc.stdout is not None
+        proc = self._proc
+        assert proc is not None
+        assert proc.stdout is not None
+        failure: BaseException | None = None
         try:
-            async for raw_line in iter_bytes_lines(self._proc.stdout):
+            async for raw_line in iter_bytes_lines(proc.stdout):
                 line = raw_line.strip()
                 if not line:
                     continue
@@ -856,7 +858,14 @@ class _AppServerClient:
                     continue
                 await self._route_response(message)
         except Exception as exc:  # noqa: BLE001
-            await self._fail_all(exc)
+            failure = exc
+        if failure is None:
+            failure = RuntimeError("codex app-server closed stdout")
+        async with self._state_lock:
+            if self._proc is proc:
+                self._proc = None
+                self._loaded_threads.clear()
+        await self._fail_all(failure)
 
     def _handle_server_request(self, message: dict[str, Any]) -> dict[str, Any]:
         method = message.get("method")
@@ -907,6 +916,7 @@ class _AppServerClient:
             self._waiters.clear()
             senders = list(self._turn_senders.values())
             self._turn_senders.clear()
+            self._pending_by_turn.clear()
         for waiter in waiters:
             waiter.error = RuntimeError(f"codex app-server closed: {exc}")
             waiter.event.set()

--- a/src/takopi/runners/codex.py
+++ b/src/takopi/runners/codex.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import asyncio
+import json
+import os
 import re
+import subprocess
+import uuid
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import anyio
 import msgspec
 
 from ..backends import EngineBackend, EngineConfig
@@ -12,10 +19,11 @@ from ..config import ConfigError
 from ..events import EventFactory
 from ..logging import get_logger
 from ..model import ActionPhase, EngineId, ResumeToken, TakopiEvent
-from ..runner import JsonlSubprocessRunner, ResumeTokenMixin, Runner
+from ..runner import BaseRunner, JsonlSubprocessRunner, ResumeTokenMixin, Runner
 from .run_options import get_run_options
 from ..schemas import codex as codex_schema
-from ..utils.paths import relativize_command
+from ..utils.paths import get_run_base_dir, relativize_command
+from ..utils.streams import drain_stderr, iter_bytes_lines
 
 logger = get_logger(__name__)
 
@@ -23,6 +31,7 @@ ENGINE: EngineId = "codex"
 
 __all__ = [
     "ENGINE",
+    "AppServerCodexRunner",
     "CodexRunner",
     "find_exec_only_flag",
     "translate_codex_event",
@@ -663,8 +672,664 @@ class CodexRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         ]
 
 
+@dataclass(slots=True)
+class _AppServerWaiter:
+    event: anyio.Event = field(default_factory=anyio.Event)
+    result: Any | None = None
+    error: Exception | None = None
+
+
+class _AppServerClient:
+    def __init__(self, *, codex_cmd: str, extra_args: list[str]) -> None:
+        self.codex_cmd = codex_cmd
+        self.extra_args = extra_args
+        self._proc: Any | None = None
+        self._reader_task: asyncio.Task | None = None
+        self._stderr_task: asyncio.Task | None = None
+        self._start_lock = anyio.Lock()
+        self._write_lock = anyio.Lock()
+        self._state_lock = anyio.Lock()
+        self._waiters: dict[str, _AppServerWaiter] = {}
+        self._turn_senders: dict[str, Any] = {}
+        self._pending_by_turn: dict[str, list[dict[str, Any]]] = {}
+        self._loaded_threads: set[str] = set()
+
+    async def start(self) -> None:
+        async with self._start_lock:
+            if self._proc is not None:
+                return
+
+            cmd = [
+                self.codex_cmd,
+                *self.extra_args,
+                "app-server",
+                "--listen",
+                "stdio://",
+            ]
+            kwargs: dict[str, Any] = {
+                "stdin": subprocess.PIPE,
+                "stdout": subprocess.PIPE,
+                "stderr": subprocess.PIPE,
+                "cwd": get_run_base_dir(),
+            }
+            if os.name == "posix":
+                kwargs["start_new_session"] = True
+            self._proc = await anyio.open_process(cmd, **kwargs)
+
+            if (
+                self._proc.stdin is None
+                or self._proc.stdout is None
+                or self._proc.stderr is None
+            ):
+                raise RuntimeError("codex app-server failed to open subprocess pipes")
+
+            self._reader_task = asyncio.create_task(self._reader_loop())
+            self._stderr_task = asyncio.create_task(
+                drain_stderr(self._proc.stderr, logger, ENGINE)
+            )
+
+            result = await self.request(
+                "initialize",
+                {
+                    "clientInfo": {
+                        "name": "takopi",
+                        "title": "Takopi",
+                        "version": "0",
+                    },
+                    "capabilities": {"experimentalApi": True},
+                },
+            )
+            if not isinstance(result, dict):
+                raise RuntimeError("codex app-server initialize returned non-object")
+            await self.notify("initialized", {})
+
+    async def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        await self._write({"method": method, "params": params or {}})
+
+    async def request(self, method: str, params: dict[str, Any]) -> Any:
+        if method != "initialize":
+            await self.start()
+        request_id = str(uuid.uuid4())
+        waiter = _AppServerWaiter()
+        async with self._state_lock:
+            self._waiters[request_id] = waiter
+        try:
+            await self._write({"id": request_id, "method": method, "params": params})
+        except BaseException:
+            async with self._state_lock:
+                self._waiters.pop(request_id, None)
+            raise
+
+        await waiter.event.wait()
+        if waiter.error is not None:
+            raise waiter.error
+        return waiter.result
+
+    async def thread_start(self, params: dict[str, Any]) -> dict[str, Any]:
+        result = await self.request("thread/start", params)
+        if not isinstance(result, dict):
+            raise RuntimeError("thread/start returned non-object")
+        thread = result.get("thread")
+        if not isinstance(thread, dict) or not isinstance(thread.get("id"), str):
+            raise RuntimeError("thread/start returned no thread id")
+        async with self._state_lock:
+            self._loaded_threads.add(thread["id"])
+        return result
+
+    async def ensure_thread_loaded(self, thread_id: str) -> None:
+        async with self._state_lock:
+            if thread_id in self._loaded_threads:
+                return
+        result = await self.request("thread/resume", {"threadId": thread_id})
+        if not isinstance(result, dict):
+            raise RuntimeError("thread/resume returned non-object")
+        async with self._state_lock:
+            self._loaded_threads.add(thread_id)
+
+    async def turn_start(self, thread_id: str, params: dict[str, Any]) -> dict[str, Any]:
+        payload = {"threadId": thread_id, **params}
+        result = await self.request("turn/start", payload)
+        if not isinstance(result, dict):
+            raise RuntimeError("turn/start returned non-object")
+        return result
+
+    async def turn_steer(self, thread_id: str, turn_id: str, text: str) -> None:
+        result = await self.request(
+            "turn/steer",
+            {
+                "threadId": thread_id,
+                "expectedTurnId": turn_id,
+                "input": [{"type": "text", "text": text}],
+            },
+        )
+        if not isinstance(result, dict) or result.get("turnId") != turn_id:
+            raise RuntimeError("turn/steer returned unexpected turn id")
+
+    async def turn_interrupt(self, thread_id: str, turn_id: str) -> bool:
+        await self.request("turn/interrupt", {"threadId": thread_id, "turnId": turn_id})
+        return True
+
+    async def subscribe_turn(self, turn_id: str) -> Any:
+        send, receive = anyio.create_memory_object_stream[dict[str, Any]](1000)
+        while True:
+            async with self._state_lock:
+                pending = self._pending_by_turn.pop(turn_id, [])
+                if not pending:
+                    self._turn_senders[turn_id] = send
+                    return receive
+            for message in pending:
+                await send.send(message)
+
+    async def unsubscribe_turn(self, turn_id: str) -> None:
+        async with self._state_lock:
+            sender = self._turn_senders.pop(turn_id, None)
+        if sender is not None:
+            await sender.aclose()
+
+    async def _write(self, payload: dict[str, Any]) -> None:
+        if self._proc is None or self._proc.stdin is None:
+            raise RuntimeError("codex app-server is not running")
+        data = json.dumps(payload, separators=(",", ":")).encode() + b"\n"
+        async with self._write_lock:
+            await self._proc.stdin.send(data)
+
+    async def _reader_loop(self) -> None:
+        assert self._proc is not None
+        assert self._proc.stdout is not None
+        try:
+            async for raw_line in iter_bytes_lines(self._proc.stdout):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    message = json.loads(line.decode("utf-8"))
+                except json.JSONDecodeError as exc:
+                    raise RuntimeError(f"invalid JSON-RPC from codex app-server: {line!r}") from exc
+                if not isinstance(message, dict):
+                    continue
+                if "method" in message and "id" in message:
+                    response = self._handle_server_request(message)
+                    await self._write({"id": message["id"], "result": response})
+                    continue
+                if "method" in message:
+                    await self._route_notification(message)
+                    continue
+                await self._route_response(message)
+        except Exception as exc:  # noqa: BLE001
+            await self._fail_all(exc)
+
+    def _handle_server_request(self, message: dict[str, Any]) -> dict[str, Any]:
+        method = message.get("method")
+        params = message.get("params")
+        if method in {
+            "item/commandExecution/requestApproval",
+            "item/fileChange/requestApproval",
+        }:
+            return {"decision": "accept"}
+        if method == "item/permissions/requestApproval" and isinstance(params, dict):
+            permissions = params.get("permissions")
+            return {"scope": "turn", "permissions": permissions or {}}
+        if method == "mcpServer/elicitation/request":
+            return {"action": "decline", "content": None}
+        return {}
+
+    async def _route_response(self, message: dict[str, Any]) -> None:
+        request_id = str(message.get("id"))
+        async with self._state_lock:
+            waiter = self._waiters.pop(request_id, None)
+        if waiter is None:
+            return
+        if "error" in message:
+            error = message.get("error")
+            text = error.get("message") if isinstance(error, dict) else None
+            waiter.error = RuntimeError(str(text or error or "codex app-server error"))
+        else:
+            waiter.result = message.get("result")
+        waiter.event.set()
+
+    async def _route_notification(self, message: dict[str, Any]) -> None:
+        turn_id = _app_notification_turn_id(message)
+        if turn_id is None:
+            return
+        async with self._state_lock:
+            sender = self._turn_senders.get(turn_id)
+            if sender is None:
+                self._pending_by_turn.setdefault(turn_id, []).append(message)
+                return
+        try:
+            await sender.send(message)
+        except anyio.ClosedResourceError:
+            return
+
+    async def _fail_all(self, exc: BaseException) -> None:
+        async with self._state_lock:
+            waiters = list(self._waiters.values())
+            self._waiters.clear()
+            senders = list(self._turn_senders.values())
+            self._turn_senders.clear()
+        for waiter in waiters:
+            waiter.error = RuntimeError(f"codex app-server closed: {exc}")
+            waiter.event.set()
+        for sender in senders:
+            await sender.aclose()
+
+
+def _app_notification_turn_id(message: dict[str, Any]) -> str | None:
+    params = message.get("params")
+    if not isinstance(params, dict):
+        return None
+    turn_id = params.get("turnId")
+    if isinstance(turn_id, str):
+        return turn_id
+    turn = params.get("turn")
+    if isinstance(turn, dict) and isinstance(turn.get("id"), str):
+        return turn["id"]
+    return None
+
+
+@dataclass(slots=True)
+class _AppServerRunState:
+    factory: EventFactory
+    final_answer: str | None = None
+    turn_agent_messages: list[_AgentMessageSummary] = field(default_factory=list)
+    agent_message_phases: dict[str, str | None] = field(default_factory=dict)
+    agent_message_text: dict[str, str] = field(default_factory=dict)
+    started_commentary_messages: set[str] = field(default_factory=set)
+
+
+@dataclass(frozen=True, slots=True)
+class _AppServerTurnControl:
+    client: _AppServerClient
+    thread_id: str
+    turn_id: str
+
+    async def steer(self, text: str) -> None:
+        await self.client.turn_steer(self.thread_id, self.turn_id, text)
+
+    async def interrupt(self) -> bool:
+        return await self.client.turn_interrupt(self.thread_id, self.turn_id)
+
+
+def _app_item_title(item: dict[str, Any]) -> str:
+    item_type = item.get("type")
+    if item_type == "commandExecution":
+        return relativize_command(str(item.get("command") or "command"))
+    if item_type == "mcpToolCall":
+        return _short_tool_name(item.get("server"), item.get("tool"))
+    if item_type == "fileChange":
+        changes = item.get("changes")
+        if isinstance(changes, list):
+            paths = [str(change.get("path")) for change in changes if isinstance(change, dict) and change.get("path")]
+            return ", ".join(paths) if paths else f"{len(changes)} files"
+        return "files"
+    if item_type == "webSearch":
+        return str(item.get("query") or "web search")
+    if item_type == "plan":
+        return str(item.get("text") or "plan")
+    if item_type == "reasoning":
+        summary = item.get("summary")
+        if isinstance(summary, list) and summary:
+            return str(summary[-1])
+        return "reasoning"
+    return str(item_type or "item")
+
+
+def _translate_app_item_event(
+    method: str,
+    item: dict[str, Any],
+    *,
+    state: _AppServerRunState,
+) -> list[TakopiEvent]:
+    item_id = str(item.get("id") or "")
+    item_type = item.get("type")
+    if not item_id:
+        return []
+
+    phase: ActionPhase | None
+    if method == "item/started":
+        phase = "started"
+    elif method == "item/completed":
+        phase = "completed"
+    else:
+        phase = None
+    if phase is None:
+        return []
+
+    factory = state.factory
+    if item_type == "agentMessage":
+        text = str(item.get("text") or "")
+        message_phase = item.get("phase")
+        message_phase = message_phase if isinstance(message_phase, str) else None
+        state.agent_message_phases[item_id] = message_phase
+        state.agent_message_text[item_id] = text
+        if method == "item/completed":
+            state.turn_agent_messages.append(
+                _AgentMessageSummary(text=text, phase=message_phase)
+            )
+            selected = _select_final_answer(state.turn_agent_messages)
+            if selected is not None:
+                state.final_answer = selected
+        if message_phase == "commentary":
+            detail = {"phase": "commentary"}
+            if phase == "started":
+                if not text:
+                    return []
+                state.started_commentary_messages.add(item_id)
+                return [
+                    factory.action_started(
+                        action_id=item_id,
+                        kind="note",
+                        title=text,
+                        detail=detail,
+                    )
+                ]
+            if not text:
+                return []
+            return [
+                factory.action_completed(
+                    action_id=item_id,
+                    kind="note",
+                    title=text,
+                    detail=detail,
+                    ok=True,
+                )
+            ]
+        return []
+
+    if item_type == "commandExecution":
+        status = item.get("status")
+        detail = {
+            "exit_code": item.get("exitCode"),
+            "status": status,
+            "cwd": item.get("cwd"),
+        }
+        title = _app_item_title(item)
+        if phase == "started":
+            return [factory.action_started(action_id=item_id, kind="command", title=title, detail=detail)]
+        ok = status == "completed"
+        exit_code = item.get("exitCode")
+        if isinstance(exit_code, int):
+            ok = ok and exit_code == 0
+        return [
+            factory.action_completed(
+                action_id=item_id,
+                kind="command",
+                title=title,
+                detail=detail,
+                ok=ok,
+            )
+        ]
+
+    if item_type == "mcpToolCall":
+        status = item.get("status")
+        detail = {
+            "server": item.get("server"),
+            "tool": item.get("tool"),
+            "status": status,
+            "arguments": item.get("arguments"),
+        }
+        error = item.get("error")
+        if isinstance(error, dict):
+            detail["error_message"] = str(error.get("message") or error)
+        title = _app_item_title(item)
+        if phase == "started":
+            return [factory.action_started(action_id=item_id, kind="tool", title=title, detail=detail)]
+        return [
+            factory.action_completed(
+                action_id=item_id,
+                kind="tool",
+                title=title,
+                detail=detail,
+                ok=status == "completed" and error is None,
+            )
+        ]
+
+    if item_type == "fileChange":
+        if phase != "completed":
+            return []
+        changes = item.get("changes")
+        normalized_changes = _normalize_change_list(changes if isinstance(changes, list) else [])
+        status = item.get("status")
+        return [
+            factory.action_completed(
+                action_id=item_id,
+                kind="file_change",
+                title=_app_item_title(item),
+                detail={"changes": normalized_changes, "status": status, "error": None},
+                ok=status == "completed",
+            )
+        ]
+
+    if item_type == "webSearch":
+        detail = {"query": item.get("query"), "action": item.get("action")}
+        title = _app_item_title(item)
+        if phase == "started":
+            return [factory.action_started(action_id=item_id, kind="web_search", title=title, detail=detail)]
+        return [
+            factory.action_completed(
+                action_id=item_id,
+                kind="web_search",
+                title=title,
+                detail=detail,
+                ok=True,
+            )
+        ]
+
+    if item_type == "reasoning":
+        return []
+
+    if item_type in {"plan", "contextCompaction"}:
+        title = _app_item_title(item)
+        if phase == "started":
+            return [factory.action_started(action_id=item_id, kind="note", title=title)]
+        return [
+            factory.action_completed(
+                action_id=item_id,
+                kind="note",
+                title=title,
+                ok=True,
+            )
+        ]
+
+    return []
+
+
+def _translate_app_notification(
+    message: dict[str, Any],
+    *,
+    state: _AppServerRunState,
+    resume: ResumeToken,
+) -> list[TakopiEvent]:
+    method = message.get("method")
+    params = message.get("params")
+    if not isinstance(method, str) or not isinstance(params, dict):
+        return []
+    factory = state.factory
+
+    if method == "turn/started":
+        turn = params.get("turn")
+        turn_id = turn.get("id") if isinstance(turn, dict) else params.get("turnId")
+        return [
+            factory.action_started(
+                action_id=str(turn_id or "turn"),
+                kind="turn",
+                title="turn started",
+            )
+        ]
+
+    if method == "item/agentMessage/delta":
+        item_id = params.get("itemId")
+        delta = params.get("delta")
+        if not isinstance(item_id, str) or not isinstance(delta, str):
+            return []
+        text = state.agent_message_text.get(item_id, "") + delta
+        state.agent_message_text[item_id] = text
+        if state.agent_message_phases.get(item_id) == "commentary":
+            if not text:
+                return []
+            if item_id not in state.started_commentary_messages:
+                state.started_commentary_messages.add(item_id)
+                return [
+                    factory.action_started(
+                        action_id=item_id,
+                        kind="note",
+                        title=text,
+                        detail={"phase": "commentary"},
+                    )
+                ]
+            return [
+                factory.action_updated(
+                    action_id=item_id,
+                    kind="note",
+                    title=text,
+                    detail={"phase": "commentary"},
+                )
+            ]
+        return []
+
+    if method in {"item/started", "item/completed"}:
+        item = params.get("item")
+        if isinstance(item, dict):
+            return _translate_app_item_event(method, item, state=state)
+        return []
+
+    if method == "turn/plan/updated":
+        plan = params.get("plan")
+        if not isinstance(plan, list):
+            return []
+        total = len(plan)
+        done = sum(
+            1
+            for item in plan
+            if isinstance(item, dict) and item.get("status") == "completed"
+        )
+        next_text = None
+        for item in plan:
+            if isinstance(item, dict) and item.get("status") != "completed":
+                raw_step = item.get("step")
+                next_text = str(raw_step) if raw_step is not None else None
+                break
+        summary = _TodoSummary(done=done, total=total, next_text=next_text)
+        return [
+            factory.action_updated(
+                action_id="app.plan",
+                kind="note",
+                title=_todo_title(summary),
+                detail={"done": done, "total": total},
+            )
+        ]
+
+    if method == "turn/completed":
+        turn = params.get("turn")
+        status = turn.get("status") if isinstance(turn, dict) else None
+        error_message = None
+        if isinstance(turn, dict):
+            error = turn.get("error")
+            if isinstance(error, dict):
+                error_message = str(error.get("message") or "")
+        ok = status == "completed"
+        if ok:
+            return [
+                factory.completed_ok(
+                    answer=state.final_answer or "",
+                    resume=resume,
+                )
+            ]
+        return [
+            factory.completed_error(
+                error=error_message or str(status or "turn failed"),
+                answer=state.final_answer or "",
+                resume=resume,
+            )
+        ]
+
+    return []
+
+
+class AppServerCodexRunner(ResumeTokenMixin, BaseRunner):
+    engine: EngineId = ENGINE
+    resume_re = _RESUME_RE
+    logger = logger
+
+    def __init__(
+        self,
+        *,
+        codex_cmd: str,
+        extra_args: list[str],
+        title: str = "Codex",
+    ) -> None:
+        self.codex_cmd = codex_cmd
+        self.extra_args = extra_args
+        self.session_title = title
+        self._client = _AppServerClient(codex_cmd=codex_cmd, extra_args=extra_args)
+
+    async def run_impl(
+        self, prompt: str, resume: ResumeToken | None
+    ) -> AsyncIterator[TakopiEvent]:
+        client = self._client
+        await client.start()
+
+        run_options = get_run_options()
+        if resume is not None:
+            thread_id = resume.value
+            await client.ensure_thread_loaded(thread_id)
+        else:
+            thread_params: dict[str, Any] = {"cwd": str(get_run_base_dir())}
+            if run_options is not None and run_options.model:
+                thread_params["model"] = str(run_options.model)
+            thread_started = await client.thread_start(thread_params)
+            thread = thread_started["thread"]
+            thread_id = str(thread["id"])
+
+        token = ResumeToken(engine=ENGINE, value=thread_id)
+        turn_params: dict[str, Any] = {"input": [{"type": "text", "text": prompt}]}
+        if run_options is not None:
+            if run_options.model:
+                turn_params["model"] = str(run_options.model)
+            if run_options.reasoning:
+                turn_params["effort"] = str(run_options.reasoning)
+
+        turn_started = await client.turn_start(thread_id, turn_params)
+        turn = turn_started.get("turn")
+        if not isinstance(turn, dict) or not isinstance(turn.get("id"), str):
+            raise RuntimeError("turn/start returned no turn id")
+        turn_id = turn["id"]
+        control = _AppServerTurnControl(client=client, thread_id=thread_id, turn_id=turn_id)
+        yield EventFactory(ENGINE).started(
+            token,
+            title=self.session_title,
+            meta={"turn_id": turn_id, "control": control},
+        )
+
+        state = _AppServerRunState(factory=EventFactory(ENGINE))
+        receive = await client.subscribe_turn(turn_id)
+        try:
+            async with receive:
+                async for message in receive:
+                    events = _translate_app_notification(
+                        message,
+                        state=state,
+                        resume=token,
+                    )
+                    done = False
+                    for event in events:
+                        yield event
+                        if event.type == "completed":
+                            done = True
+                    if done:
+                        return
+        finally:
+            await client.unsubscribe_turn(turn_id)
+
+
 def build_runner(config: EngineConfig, config_path: Path) -> Runner:
     codex_cmd = "codex"
+
+    mode_value = config.get("mode", "app_server")
+    if mode_value not in {"app_server", "exec"}:
+        raise ConfigError(
+            f"Invalid `codex.mode` in {config_path}; expected 'app_server' or 'exec'."
+        )
 
     extra_args_value = config.get("extra_args")
     if extra_args_value is None:
@@ -695,7 +1360,9 @@ def build_runner(config: EngineConfig, config_path: Path) -> Runner:
         extra_args.extend(["--profile", profile_value])
         title = profile_value
 
-    return CodexRunner(codex_cmd=codex_cmd, extra_args=extra_args, title=title)
+    if mode_value == "exec":
+        return CodexRunner(codex_cmd=codex_cmd, extra_args=extra_args, title=title)
+    return AppServerCodexRunner(codex_cmd=codex_cmd, extra_args=extra_args, title=title)
 
 
 BACKEND = EngineBackend(

--- a/src/takopi/scheduler.py
+++ b/src/takopi/scheduler.py
@@ -118,6 +118,13 @@ class ThreadScheduler:
                 self._pending_by_thread.pop(thread_key, None)
             return job
 
+    async def get_queued(
+        self, chat_id: ChannelId, progress_msg_id: MessageId
+    ) -> ThreadJob | None:
+        progress_key = (chat_id, progress_msg_id)
+        async with self._lock:
+            return self._queued_by_progress.get(progress_key)
+
     async def _clear_busy(self, key: str, done: anyio.Event) -> None:
         await done.wait()
         async with self._lock:
@@ -134,13 +141,19 @@ class ThreadScheduler:
                         self._pending_by_thread.pop(key, None)
                         self._active_threads.discard(key)
                         return
+
+                if done is not None and not done.is_set():
+                    await done.wait()
+                    continue
+
+                async with self._lock:
+                    queue = self._pending_by_thread.get(key)
+                    if not queue:
+                        continue
                     job = queue.popleft()
                     if job.progress_ref is not None:
                         progress_key = (job.chat_id, job.progress_ref.message_id)
                         self._queued_by_progress.pop(progress_key, None)
-
-                if done is not None and not done.is_set():
-                    await done.wait()
 
                 try:
                     await self._run_job(job)

--- a/src/takopi/scheduler.py
+++ b/src/takopi/scheduler.py
@@ -101,22 +101,30 @@ class ThreadScheduler:
     async def cancel_queued(
         self, chat_id: ChannelId, progress_msg_id: MessageId
     ) -> ThreadJob | None:
-        progress_key = (chat_id, progress_msg_id)
         async with self._lock:
-            job = self._queued_by_progress.pop(progress_key, None)
-            if job is None:
-                return None
-            thread_key = self.thread_key(job.resume_token)
-            queue = self._pending_by_thread.get(thread_key)
+            return self._pop_queued_locked(chat_id, progress_msg_id)
+
+    async def claim_queued(
+        self, chat_id: ChannelId, progress_msg_id: MessageId
+    ) -> ThreadJob | None:
+        async with self._lock:
+            return self._pop_queued_locked(chat_id, progress_msg_id)
+
+    async def requeue_front(self, job: ThreadJob) -> None:
+        key = self.thread_key(job.resume_token)
+        async with self._lock:
+            queue = self._pending_by_thread.get(key)
             if queue is None:
-                return None
-            try:
-                queue.remove(job)
-            except ValueError:
-                return None
-            if not queue:
-                self._pending_by_thread.pop(thread_key, None)
-            return job
+                queue = deque()
+                self._pending_by_thread[key] = queue
+            queue.appendleft(job)
+            if job.progress_ref is not None:
+                progress_key = (job.chat_id, job.progress_ref.message_id)
+                self._queued_by_progress[progress_key] = job
+            if key in self._active_threads:
+                return
+            self._active_threads.add(key)
+        self._task_group.start_soon(self._thread_worker, key)
 
     async def get_queued(
         self, chat_id: ChannelId, progress_msg_id: MessageId
@@ -124,6 +132,26 @@ class ThreadScheduler:
         progress_key = (chat_id, progress_msg_id)
         async with self._lock:
             return self._queued_by_progress.get(progress_key)
+
+    def _pop_queued_locked(
+        self, chat_id: ChannelId, progress_msg_id: MessageId
+    ) -> ThreadJob | None:
+        progress_key = (chat_id, progress_msg_id)
+        job = self._queued_by_progress.get(progress_key)
+        if job is None:
+            return None
+        thread_key = self.thread_key(job.resume_token)
+        queue = self._pending_by_thread.get(thread_key)
+        if queue is None:
+            return None
+        try:
+            queue.remove(job)
+        except ValueError:
+            return None
+        self._queued_by_progress.pop(progress_key, None)
+        if not queue:
+            self._pending_by_thread.pop(thread_key, None)
+        return job
 
     async def _clear_busy(self, key: str, done: anyio.Event) -> None:
         await done.wait()

--- a/src/takopi/scheduler.py
+++ b/src/takopi/scheduler.py
@@ -133,6 +133,12 @@ class ThreadScheduler:
         async with self._lock:
             return self._queued_by_progress.get(progress_key)
 
+    async def is_busy(self, token: ResumeToken) -> bool:
+        key = self.thread_key(token)
+        async with self._lock:
+            done = self._busy_until.get(key)
+            return done is not None and not done.is_set()
+
     def _pop_queued_locked(
         self, chat_id: ChannelId, progress_msg_id: MessageId
     ) -> ThreadJob | None:

--- a/src/takopi/telegram/bridge.py
+++ b/src/takopi/telegram/bridge.py
@@ -30,6 +30,7 @@ __all__ = [
     "TelegramTransport",
     "build_bot_commands",
     "handle_callback_cancel",
+    "handle_callback_steer",
     "handle_cancel",
     "is_cancel_command",
     "run_main_loop",
@@ -37,8 +38,17 @@ __all__ = [
 ]
 
 CANCEL_CALLBACK_DATA = "takopi:cancel"
+STEER_CALLBACK_DATA = "takopi:steer"
 CANCEL_MARKUP = {
     "inline_keyboard": [[{"text": "cancel", "callback_data": CANCEL_CALLBACK_DATA}]]
+}
+STEER_CANCEL_MARKUP = {
+    "inline_keyboard": [
+        [
+            {"text": "steer", "callback_data": STEER_CALLBACK_DATA},
+            {"text": "cancel", "callback_data": CANCEL_CALLBACK_DATA},
+        ]
+    ]
 }
 CLEAR_MARKUP = {"inline_keyboard": []}
 
@@ -64,7 +74,12 @@ class TelegramPresenter:
             state, elapsed_s=elapsed_s, label=label
         )
         text, entities = prepare_telegram(parts)
-        reply_markup = CLEAR_MARKUP if _is_cancelled_label(label) else CANCEL_MARKUP
+        if _is_terminal_progress_label(label):
+            reply_markup = CLEAR_MARKUP
+        elif label.strip().lower() == "queued":
+            reply_markup = STEER_CANCEL_MARKUP
+        else:
+            reply_markup = CANCEL_MARKUP
         return RenderedMessage(
             text=text,
             extra={"entities": entities, "reply_markup": reply_markup},
@@ -105,11 +120,15 @@ class TelegramPresenter:
         )
 
 
-def _is_cancelled_label(label: str) -> bool:
+def _normalized_progress_label(label: str) -> str:
     stripped = label.strip()
     if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
         stripped = stripped[1:-1]
-    return stripped.lower() == "cancelled"
+    return stripped.lower()
+
+
+def _is_terminal_progress_label(label: str) -> bool:
+    return _normalized_progress_label(label) in {"cancelled", "steered"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -357,6 +376,17 @@ async def handle_callback_cancel(
     from .commands import handle_callback_cancel as _handle_callback_cancel
 
     await _handle_callback_cancel(cfg, query, running_tasks, scheduler)
+
+
+async def handle_callback_steer(
+    cfg: TelegramBridgeConfig,
+    query: TelegramCallbackQuery,
+    running_tasks: RunningTasks,
+    scheduler: ThreadScheduler | None = None,
+) -> None:
+    from .commands import handle_callback_steer as _handle_callback_steer
+
+    await _handle_callback_steer(cfg, query, running_tasks, scheduler)
 
 
 async def send_with_resume(

--- a/src/takopi/telegram/commands/__init__.py
+++ b/src/takopi/telegram/commands/__init__.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from .cancel import handle_callback_cancel, handle_cancel
+from .cancel import handle_callback_cancel, handle_callback_steer, handle_cancel
 from .menu import build_bot_commands
 from .parse import is_cancel_command
 
 __all__ = [
     "build_bot_commands",
     "handle_callback_cancel",
+    "handle_callback_steer",
     "handle_cancel",
     "is_cancel_command",
 ]

--- a/src/takopi/telegram/commands/cancel.py
+++ b/src/takopi/telegram/commands/cancel.py
@@ -99,10 +99,86 @@ async def handle_callback_cancel(
     )
 
 
+async def handle_callback_steer(
+    cfg: TelegramBridgeConfig,
+    query: TelegramCallbackQuery,
+    running_tasks: RunningTasks,
+    scheduler: ThreadScheduler | None = None,
+) -> None:
+    if scheduler is None:
+        await cfg.bot.answer_callback_query(
+            callback_query_id=query.callback_query_id,
+            text="no queue is available.",
+        )
+        return
+
+    progress_ref = MessageRef(channel_id=query.chat_id, message_id=query.message_id)
+    job = await scheduler.get_queued(query.chat_id, query.message_id)
+    if job is None:
+        await cfg.bot.answer_callback_query(
+            callback_query_id=query.callback_query_id,
+            text="this message is not queued.",
+        )
+        return
+
+    control = None
+    for running_task in running_tasks.values():
+        if running_task.resume == job.resume_token:
+            control = running_task.control
+            break
+    if control is None:
+        await cfg.bot.answer_callback_query(
+            callback_query_id=query.callback_query_id,
+            text="active turn is not steerable; still queued.",
+        )
+        return
+
+    try:
+        await control.steer(job.text)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "steer.failed",
+            chat_id=query.chat_id,
+            progress_message_id=query.message_id,
+            resume=job.resume_token.value,
+            error=str(exc),
+            error_type=exc.__class__.__name__,
+        )
+        await cfg.bot.answer_callback_query(
+            callback_query_id=query.callback_query_id,
+            text="could not steer; still queued.",
+        )
+        return
+
+    removed = await scheduler.cancel_queued(query.chat_id, query.message_id)
+    if removed is None:
+        await cfg.bot.answer_callback_query(
+            callback_query_id=query.callback_query_id,
+            text="already left the queue.",
+        )
+        return
+
+    await _edit_labelled_message(cfg, progress_ref, removed, label="steered")
+    await cfg.bot.answer_callback_query(
+        callback_query_id=query.callback_query_id,
+        text="steered active turn.",
+    )
+
+
 async def _edit_cancelled_message(
     cfg: TelegramBridgeConfig,
     progress_ref: MessageRef,
     job: ThreadJob,
+) -> None:
+    await _edit_labelled_message(cfg, progress_ref, job, label="cancelled")
+
+
+async def _edit_labelled_message(
+    cfg: TelegramBridgeConfig,
+    progress_ref: MessageRef,
+    job: ThreadJob,
+    *,
+    label: str,
 ) -> None:
     tracker = ProgressTracker(engine=job.resume_token.engine)
     tracker.set_resume(job.resume_token)
@@ -120,6 +196,6 @@ async def _edit_cancelled_message(
     message = cfg.exec_cfg.presenter.render_progress(
         state,
         elapsed_s=0.0,
-        label="`cancelled`",
+        label=label,
     )
     await cfg.exec_cfg.transport.edit(ref=progress_ref, message=message)

--- a/src/takopi/telegram/commands/cancel.py
+++ b/src/takopi/telegram/commands/cancel.py
@@ -133,14 +133,23 @@ async def handle_callback_steer(
         )
         return
 
+    claimed = await scheduler.claim_queued(query.chat_id, query.message_id)
+    if claimed is None:
+        await cfg.bot.answer_callback_query(
+            callback_query_id=query.callback_query_id,
+            text="already left the queue.",
+        )
+        return
+
     try:
-        await control.steer(job.text)
+        await control.steer(claimed.text)
     except Exception as exc:  # noqa: BLE001
+        await scheduler.requeue_front(claimed)
         logger.warning(
             "steer.failed",
             chat_id=query.chat_id,
             progress_message_id=query.message_id,
-            resume=job.resume_token.value,
+            resume=claimed.resume_token.value,
             error=str(exc),
             error_type=exc.__class__.__name__,
         )
@@ -150,15 +159,7 @@ async def handle_callback_steer(
         )
         return
 
-    removed = await scheduler.cancel_queued(query.chat_id, query.message_id)
-    if removed is None:
-        await cfg.bot.answer_callback_query(
-            callback_query_id=query.callback_query_id,
-            text="already left the queue.",
-        )
-        return
-
-    await _edit_labelled_message(cfg, progress_ref, removed, label="steered")
+    await _edit_labelled_message(cfg, progress_ref, claimed, label="steered")
     await cfg.bot.answer_callback_query(
         callback_query_id=query.callback_query_id,
         text="steered active turn.",

--- a/src/takopi/telegram/loop.py
+++ b/src/takopi/telegram/loop.py
@@ -24,8 +24,13 @@ from ..transport import MessageRef, SendOptions
 from ..transport_runtime import ResolvedMessage
 from ..context import RunContext
 from ..ids import RESERVED_CHAT_COMMANDS
-from .bridge import CANCEL_CALLBACK_DATA, TelegramBridgeConfig, send_plain
-from .commands.cancel import handle_callback_cancel, handle_cancel
+from .bridge import (
+    CANCEL_CALLBACK_DATA,
+    STEER_CALLBACK_DATA,
+    TelegramBridgeConfig,
+    send_plain,
+)
+from .commands.cancel import handle_callback_cancel, handle_callback_steer, handle_cancel
 from .commands.file_transfer import FILE_PUT_USAGE
 from .commands.handlers import (
     dispatch_command,
@@ -1847,6 +1852,14 @@ async def run_main_loop(
                     if update.data == CANCEL_CALLBACK_DATA:
                         tg.start_soon(
                             handle_callback_cancel,
+                            cfg,
+                            update,
+                            state.running_tasks,
+                            scheduler,
+                        )
+                    elif update.data == STEER_CALLBACK_DATA:
+                        tg.start_soon(
+                            handle_callback_steer,
                             cfg,
                             update,
                             state.running_tasks,

--- a/src/takopi/telegram/loop.py
+++ b/src/takopi/telegram/loop.py
@@ -30,7 +30,11 @@ from .bridge import (
     TelegramBridgeConfig,
     send_plain,
 )
-from .commands.cancel import handle_callback_cancel, handle_callback_steer, handle_cancel
+from .commands.cancel import (
+    handle_callback_cancel,
+    handle_callback_steer,
+    handle_cancel,
+)
 from .commands.file_transfer import FILE_PUT_USAGE
 from .commands.handlers import (
     dispatch_command,

--- a/src/takopi/telegram/loop.py
+++ b/src/takopi/telegram/loop.py
@@ -866,6 +866,7 @@ async def _send_queued_progress(
     thread_id: int | None,
     resume_token: ResumeToken,
     context: RunContext | None,
+    steerable: bool,
 ) -> MessageRef | None:
     tracker = ProgressTracker(engine=resume_token.engine)
     tracker.set_resume(resume_token)
@@ -887,7 +888,7 @@ async def _send_queued_progress(
     message = cfg.exec_cfg.presenter.render_progress(
         state,
         elapsed_s=0.0,
-        label="queued",
+        label="queued" if steerable else "starting",
     )
     reply_ref = MessageRef(
         channel_id=chat_id,
@@ -944,6 +945,7 @@ async def send_with_resume(
         thread_id=thread_id,
         resume_token=resume,
         context=running_task.context,
+        steerable=not running_task.done.is_set(),
     )
     await enqueue(
         chat_id,
@@ -1398,6 +1400,7 @@ async def run_main_loop(
                     thread_id=msg.thread_id,
                     resume_token=resume_token,
                     context=context,
+                    steerable=await scheduler.is_busy(resume_token),
                 )
                 await scheduler.enqueue_resume(
                     chat_id,

--- a/tests/test_codex_runner_helpers.py
+++ b/tests/test_codex_runner_helpers.py
@@ -252,6 +252,71 @@ async def test_app_server_client_fails_waiters_on_clean_eof(tmp_path: Path) -> N
         await client.start()
 
 
+def test_app_server_client_handles_server_requests() -> None:
+    client = _AppServerClient(codex_cmd="codex", extra_args=[])
+
+    assert client._handle_server_request(
+        {"method": "item/commandExecution/requestApproval"}
+    ) == {"decision": "accept"}
+    assert client._handle_server_request(
+        {"method": "item/fileChange/requestApproval"}
+    ) == {"decision": "accept"}
+    assert client._handle_server_request(
+        {
+            "method": "item/permissions/requestApproval",
+            "params": {"permissions": {"sandbox": "workspace-write"}},
+        }
+    ) == {"scope": "turn", "permissions": {"sandbox": "workspace-write"}}
+    assert client._handle_server_request(
+        {"method": "mcpServer/elicitation/request"}
+    ) == {"action": "decline", "content": None}
+    assert client._handle_server_request({"method": "other"}) == {}
+
+
+@pytest.mark.anyio
+async def test_app_server_runner_raises_on_turn_stream_eof(
+    tmp_path: Path,
+) -> None:
+    codex_path = tmp_path / "codex"
+    codex_path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json\n"
+        "import sys\n"
+        "\n"
+        "def send(payload):\n"
+        "    print(json.dumps(payload), flush=True)\n"
+        "\n"
+        "for line in sys.stdin:\n"
+        "    msg = json.loads(line)\n"
+        "    method = msg.get('method')\n"
+        "    req_id = msg.get('id')\n"
+        "    if method == 'initialize':\n"
+        "        send({'id': req_id, 'result': {'serverInfo': {'name': 'fake'}}})\n"
+        "    elif method == 'initialized':\n"
+        "        pass\n"
+        "    elif method == 'thread/start':\n"
+        "        send({'id': req_id, 'result': {'thread': {'id': 'thread-1'}}})\n"
+        "    elif method == 'turn/start':\n"
+        "        turn = {'id': 'turn-1', 'status': 'running', 'items': []}\n"
+        "        send({'id': req_id, 'result': {'turn': turn}})\n"
+        "        send({'method': 'turn/started', 'params': {'threadId': 'thread-1', 'turn': turn}})\n"
+        "        break\n",
+        encoding="utf-8",
+    )
+    codex_path.chmod(0o755)
+    runner = AppServerCodexRunner(codex_cmd=str(codex_path), extra_args=[])
+
+    stream = runner.run("hello", None)
+    with anyio.fail_after(2):
+        started = await anext(stream)
+        with pytest.raises(RuntimeError, match="closed before turn completed"):
+            async for _event in stream:
+                pass
+
+    assert isinstance(started, StartedEvent)
+    assert started.resume.value == "thread-1"
+
+
 @pytest.mark.anyio
 async def test_app_server_codex_runner_translates_turn_notifications(
     tmp_path: Path,

--- a/tests/test_codex_runner_helpers.py
+++ b/tests/test_codex_runner_helpers.py
@@ -238,11 +238,7 @@ def test_codex_runner_process_and_stream_end_events() -> None:
 async def test_app_server_client_fails_waiters_on_clean_eof(tmp_path: Path) -> None:
     codex_path = tmp_path / "codex"
     codex_path.write_text(
-        "#!/usr/bin/env python3\n"
-        "import sys\n"
-        "\n"
-        "for _line in sys.stdin:\n"
-        "    break\n",
+        "#!/usr/bin/env python3\nimport sys\n\nfor _line in sys.stdin:\n    break\n",
         encoding="utf-8",
     )
     codex_path.chmod(0o755)

--- a/tests/test_codex_runner_helpers.py
+++ b/tests/test_codex_runner_helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import anyio
 import pytest
 
 from takopi.backends import EngineConfig
@@ -10,6 +11,7 @@ from takopi.events import EventFactory
 from takopi.model import ActionEvent, CompletedEvent, StartedEvent
 from takopi.runners.codex import (
     _AgentMessageSummary,
+    AppServerCodexRunner,
     CodexRunner,
     _format_change_summary,
     _normalize_change_list,
@@ -231,17 +233,111 @@ def test_codex_runner_process_and_stream_end_events() -> None:
     assert end_event.ok is True
 
 
+@pytest.mark.anyio
+async def test_app_server_codex_runner_translates_turn_notifications(
+    tmp_path: Path,
+) -> None:
+    codex_path = tmp_path / "codex"
+    codex_path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json\n"
+        "import sys\n"
+        "\n"
+        "def send(payload):\n"
+        "    print(json.dumps(payload), flush=True)\n"
+        "\n"
+        "for line in sys.stdin:\n"
+        "    msg = json.loads(line)\n"
+        "    method = msg.get('method')\n"
+        "    req_id = msg.get('id')\n"
+        "    if method == 'initialize':\n"
+        "        assert msg['params']['clientInfo']['version']\n"
+        "        send({'id': req_id, 'result': {'serverInfo': {'name': 'fake'}}})\n"
+        "    elif method == 'initialized':\n"
+        "        pass\n"
+        "    elif method == 'thread/start':\n"
+        "        send({'id': req_id, 'result': {'thread': {'id': 'thread-1'}}})\n"
+        "    elif method == 'turn/start':\n"
+        "        turn = {'id': 'turn-1', 'status': 'running', 'items': []}\n"
+        "        send({'id': req_id, 'result': {'turn': turn}})\n"
+        "        send({'method': 'turn/started', 'params': {'threadId': 'thread-1', 'turn': turn}})\n"
+        "        send({'method': 'item/started', 'params': {'threadId': 'thread-1', 'turnId': 'turn-1', 'item': {'id': 'r1', 'type': 'reasoning', 'summary': []}}})\n"
+        "        send({'method': 'item/completed', 'params': {'threadId': 'thread-1', 'turnId': 'turn-1', 'item': {'id': 'r1', 'type': 'reasoning', 'summary': []}}})\n"
+        "        send({'method': 'item/started', 'params': {'threadId': 'thread-1', 'turnId': 'turn-1', 'item': {'id': 'c1', 'type': 'agentMessage', 'phase': 'commentary', 'text': ''}}})\n"
+        "        send({'method': 'item/agentMessage/delta', 'params': {'threadId': 'thread-1', 'turnId': 'turn-1', 'itemId': 'c1', 'delta': 'work'}})\n"
+        "        send({'method': 'item/agentMessage/delta', 'params': {'threadId': 'thread-1', 'turnId': 'turn-1', 'itemId': 'c1', 'delta': 'ing'}})\n"
+        "        send({'method': 'item/completed', 'params': {'threadId': 'thread-1', 'turnId': 'turn-1', 'item': {'id': 'c1', 'type': 'agentMessage', 'phase': 'commentary', 'text': 'working'}}})\n"
+        "        send({'method': 'item/completed', 'params': {'threadId': 'thread-1', 'turnId': 'turn-1', 'item': {'id': 'a1', 'type': 'agentMessage', 'phase': 'final_answer', 'text': 'done'}}})\n"
+        "        send({'method': 'turn/completed', 'params': {'threadId': 'thread-1', 'turn': {'id': 'turn-1', 'status': 'completed', 'items': []}}})\n"
+        "        break\n",
+        encoding="utf-8",
+    )
+    codex_path.chmod(0o755)
+    runner = AppServerCodexRunner(codex_cmd=str(codex_path), extra_args=[])
+
+    with anyio.fail_after(2):
+        events = [event async for event in runner.run("hello", None)]
+
+    assert isinstance(events[0], StartedEvent)
+    assert events[0].resume.value == "thread-1"
+    assert events[0].meta is not None
+    assert events[0].meta["turn_id"] == "turn-1"
+    event_summary = [
+        (
+            event.type,
+            getattr(event, "phase", None),
+            getattr(getattr(event, "action", None), "kind", None),
+            getattr(getattr(event, "action", None), "title", None),
+        )
+        for event in events
+    ]
+    assert any(
+        isinstance(event, ActionEvent)
+        and event.phase == "started"
+        and event.action.kind == "note"
+        and event.action.title == "work"
+        and event.action.detail == {"phase": "commentary"}
+        for event in events
+    ), event_summary
+    assert any(
+        isinstance(event, ActionEvent)
+        and event.phase == "updated"
+        and event.action.kind == "note"
+        and event.action.title == "working"
+        and event.action.detail == {"phase": "commentary"}
+        for event in events
+    ), event_summary
+    assert not any(
+        isinstance(event, ActionEvent) and event.action.title == "commentary"
+        for event in events
+    ), event_summary
+    assert not any(
+        isinstance(event, ActionEvent) and event.action.title == "reasoning"
+        for event in events
+    ), event_summary
+    completed = events[-1]
+    assert isinstance(completed, CompletedEvent)
+    assert completed.ok is True
+    assert completed.answer == "done"
+
+
 def test_codex_build_runner_configs(tmp_path: Path) -> None:
     cfg: EngineConfig = {}
     runner = build_runner(cfg, tmp_path)
-    assert isinstance(runner, CodexRunner)
+    assert isinstance(runner, AppServerCodexRunner)
     assert runner.extra_args == ["-c", "notify=[]"]
 
     cfg = {"extra_args": ["--foo"], "profile": "Demo"}
     runner = build_runner(cfg, tmp_path)
-    assert isinstance(runner, CodexRunner)
+    assert isinstance(runner, AppServerCodexRunner)
     assert runner.extra_args[-2:] == ["--profile", "Demo"]
     assert runner.session_title == "Demo"
+
+    runner = build_runner({"mode": "exec"}, tmp_path)
+    assert isinstance(runner, CodexRunner)
+
+    with pytest.raises(ConfigError):
+        build_runner({"mode": "unknown"}, tmp_path)
 
     with pytest.raises(ConfigError):
         build_runner({"extra_args": ["--json"]}, tmp_path)

--- a/tests/test_codex_runner_helpers.py
+++ b/tests/test_codex_runner_helpers.py
@@ -11,6 +11,7 @@ from takopi.events import EventFactory
 from takopi.model import ActionEvent, CompletedEvent, StartedEvent
 from takopi.runners.codex import (
     _AgentMessageSummary,
+    _AppServerClient,
     AppServerCodexRunner,
     CodexRunner,
     _format_change_summary,
@@ -231,6 +232,24 @@ def test_codex_runner_process_and_stream_end_events() -> None:
     end_event = end[0]
     assert isinstance(end_event, CompletedEvent)
     assert end_event.ok is True
+
+
+@pytest.mark.anyio
+async def test_app_server_client_fails_waiters_on_clean_eof(tmp_path: Path) -> None:
+    codex_path = tmp_path / "codex"
+    codex_path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "\n"
+        "for _line in sys.stdin:\n"
+        "    break\n",
+        encoding="utf-8",
+    )
+    codex_path.chmod(0o755)
+    client = _AppServerClient(codex_cmd=str(codex_path), extra_args=[])
+
+    with anyio.fail_after(2), pytest.raises(RuntimeError, match="closed stdout"):
+        await client.start()
 
 
 @pytest.mark.anyio

--- a/tests/test_exec_render.py
+++ b/tests/test_exec_render.py
@@ -180,6 +180,37 @@ def test_progress_renderer_renders_progress_and_final() -> None:
     )
 
 
+def test_progress_renderer_renders_codex_commentary() -> None:
+    tracker = ProgressTracker(engine="codex")
+    tracker.note_event(
+        action_started(
+            "msg-1",
+            "note",
+            "Reading the app-server stream.",
+            detail={"phase": "commentary"},
+        )
+    )
+    tracker.note_event(
+        ActionEvent(
+            engine="codex",
+            action=Action(
+                id="msg-1",
+                kind="note",
+                title="Reading the app-server stream and checking Telegram output.",
+                detail={"phase": "commentary"},
+            ),
+            phase="updated",
+        )
+    )
+
+    parts = MarkdownFormatter(max_actions=5).render_progress_parts(
+        tracker.snapshot(), elapsed_s=1.0
+    )
+    progress = assemble_markdown_parts(parts)
+
+    assert "↻ Reading the app-server stream and checking Telegram output." in progress
+
+
 def test_progress_renderer_footer_includes_ctx_before_resume() -> None:
     tracker = ProgressTracker(engine="codex")
     for evt in SAMPLE_EVENTS:

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -983,6 +983,129 @@ async def test_handle_callback_steer_sends_queued_text_to_active_turn() -> None:
 
 
 @pytest.mark.anyio
+async def test_handle_callback_steer_claims_job_before_awaiting_steer() -> None:
+    transport = FakeTransport()
+    cfg = replace(
+        make_cfg(transport),
+        exec_cfg=ExecBridgeConfig(
+            transport=transport,
+            presenter=TelegramPresenter(),
+            final_notify=True,
+        ),
+    )
+    active_done = anyio.Event()
+    ran_jobs: list[str] = []
+
+    async def _run_job(job) -> None:
+        ran_jobs.append(job.text)
+
+    class _Control(RunnerTurnControl):
+        def __init__(self) -> None:
+            self.steered: list[str] = []
+
+        async def steer(self, text: str) -> None:
+            self.steered.append(text)
+            active_done.set()
+            await anyio.sleep(0)
+
+        async def interrupt(self) -> bool:
+            return True
+
+    async with anyio.create_task_group() as tg:
+        scheduler = ThreadScheduler(task_group=tg, run_job=_run_job)
+        progress_id = 89
+        progress_ref = MessageRef(channel_id=123, message_id=progress_id)
+        resume = ResumeToken(engine=CODEX_ENGINE, value="sid")
+        await scheduler.note_thread_known(resume, active_done)
+        await scheduler.enqueue_resume(
+            chat_id=123,
+            user_msg_id=10,
+            text="queued prompt",
+            resume_token=resume,
+            progress_ref=progress_ref,
+        )
+        await anyio.sleep(0)
+
+        control = _Control()
+        running_task = RunningTask(resume=resume, control=control)
+        running_tasks = {MessageRef(channel_id=123, message_id=7): running_task}
+        query = TelegramCallbackQuery(
+            transport="telegram",
+            chat_id=123,
+            message_id=progress_id,
+            callback_query_id="cbq-steer-race",
+            data="takopi:steer",
+            sender_id=123,
+        )
+
+        await telegram_loop.handle_callback_steer(cfg, query, running_tasks, scheduler)
+        await anyio.sleep(0)
+
+        assert control.steered == ["queued prompt"]
+        assert ran_jobs == []
+        assert await scheduler.get_queued(123, progress_ref.message_id) is None
+        tg.cancel_scope.cancel()
+
+
+@pytest.mark.anyio
+async def test_handle_callback_steer_requeues_when_steer_fails() -> None:
+    transport = FakeTransport()
+    cfg = replace(
+        make_cfg(transport),
+        exec_cfg=ExecBridgeConfig(
+            transport=transport,
+            presenter=TelegramPresenter(),
+            final_notify=True,
+        ),
+    )
+
+    async def _noop_run_job(_) -> None:
+        return None
+
+    class _Control(RunnerTurnControl):
+        async def steer(self, text: str) -> None:
+            _ = text
+            raise RuntimeError("nope")
+
+        async def interrupt(self) -> bool:
+            return True
+
+    scheduler = ThreadScheduler(task_group=_NoopTaskGroup(), run_job=_noop_run_job)
+    progress_id = 90
+    progress_ref = MessageRef(channel_id=123, message_id=progress_id)
+    resume = ResumeToken(engine=CODEX_ENGINE, value="sid")
+    await scheduler.enqueue_resume(
+        chat_id=123,
+        user_msg_id=10,
+        text="queued prompt",
+        resume_token=resume,
+        progress_ref=progress_ref,
+    )
+    running_task = RunningTask(resume=resume, control=_Control())
+    query = TelegramCallbackQuery(
+        transport="telegram",
+        chat_id=123,
+        message_id=progress_id,
+        callback_query_id="cbq-steer-fails",
+        data="takopi:steer",
+        sender_id=123,
+    )
+
+    await telegram_loop.handle_callback_steer(
+        cfg,
+        query,
+        {MessageRef(channel_id=123, message_id=7): running_task},
+        scheduler,
+    )
+
+    queued = await scheduler.get_queued(123, progress_ref.message_id)
+    assert queued is not None
+    assert queued.text == "queued prompt"
+    bot = cast(FakeBot, cfg.bot)
+    assert bot.callback_calls[-1]["text"] == "could not steer; still queued."
+
+
+@pytest.mark.anyio
 async def test_handle_callback_cancel_without_task_acknowledges() -> None:
     transport = FakeTransport()
     cfg = make_cfg(transport)

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -316,6 +316,36 @@ def test_telegram_presenter_progress_shows_steer_button_for_queued() -> None:
     ]
 
 
+@pytest.mark.anyio
+async def test_send_queued_progress_omits_steer_when_not_steerable() -> None:
+    transport = FakeTransport()
+    cfg = replace(
+        make_cfg(transport),
+        exec_cfg=ExecBridgeConfig(
+            transport=transport,
+            presenter=TelegramPresenter(),
+            final_notify=True,
+        ),
+    )
+
+    await telegram_loop._send_queued_progress(
+        cfg,
+        chat_id=123,
+        user_msg_id=10,
+        thread_id=None,
+        resume_token=ResumeToken(engine=CODEX_ENGINE, value="sid"),
+        context=None,
+        steerable=False,
+    )
+
+    assert transport.send_calls
+    message = transport.send_calls[0]["message"]
+    assert message.text.lower().startswith("starting")
+    assert message.extra["reply_markup"]["inline_keyboard"] == [
+        [{"text": "cancel", "callback_data": "takopi:cancel"}]
+    ]
+
+
 def test_telegram_presenter_final_clears_button() -> None:
     presenter = TelegramPresenter()
     state = ProgressTracker(engine="codex").snapshot()

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -36,6 +36,7 @@ from takopi.telegram.engine_overrides import EngineOverrides
 from takopi.context import RunContext
 from takopi.config import ProjectConfig, ProjectsConfig
 from takopi.runner_bridge import ExecBridgeConfig, RunningTask
+from takopi.runner import RunnerTurnControl
 from takopi.markdown import MarkdownPresenter
 from takopi.model import ResumeToken
 from takopi.progress import ProgressTracker
@@ -70,6 +71,42 @@ class _NoopTaskGroup:
     def start_soon(self, func, *args: Any) -> None:
         _ = func, args
         return None
+
+
+@pytest.mark.anyio
+async def test_scheduler_keeps_busy_queued_job_addressable_by_progress() -> None:
+    resume = ResumeToken(engine=CODEX_ENGINE, value="sid")
+    active_done = anyio.Event()
+    ran = anyio.Event()
+    progress_ref = MessageRef(channel_id=123, message_id=55)
+
+    async def _run_job(_) -> None:
+        ran.set()
+
+    async with anyio.create_task_group() as tg:
+        scheduler = ThreadScheduler(task_group=tg, run_job=_run_job)
+        await scheduler.note_thread_known(resume, active_done)
+        await scheduler.enqueue_resume(
+            chat_id=123,
+            user_msg_id=10,
+            text="queued prompt",
+            resume_token=resume,
+            progress_ref=progress_ref,
+        )
+
+        await anyio.sleep(0)
+
+        queued = await scheduler.get_queued(123, progress_ref.message_id)
+        assert queued is not None
+        assert queued.text == "queued prompt"
+        assert ran.is_set() is False
+
+        active_done.set()
+        with anyio.fail_after(1):
+            await ran.wait()
+        assert await scheduler.get_queued(123, progress_ref.message_id) is None
+
+        tg.cancel_scope.cancel()
 
 
 def test_parse_directives_inline_engine() -> None:
@@ -252,9 +289,31 @@ def test_telegram_presenter_clears_button_on_cancelled() -> None:
     presenter = TelegramPresenter()
     state = ProgressTracker(engine="codex").snapshot()
 
-    rendered = presenter.render_progress(state, elapsed_s=0.0, label="`cancelled`")
+    rendered = presenter.render_progress(state, elapsed_s=0.0, label="cancelled")
 
     assert rendered.extra["reply_markup"]["inline_keyboard"] == []
+
+
+def test_telegram_presenter_clears_button_on_steered() -> None:
+    presenter = TelegramPresenter()
+    state = ProgressTracker(engine="codex").snapshot()
+
+    rendered = presenter.render_progress(state, elapsed_s=0.0, label="steered")
+
+    assert rendered.extra["reply_markup"]["inline_keyboard"] == []
+
+
+def test_telegram_presenter_progress_shows_steer_button_for_queued() -> None:
+    presenter = TelegramPresenter()
+    state = ProgressTracker(engine="codex").snapshot()
+
+    rendered = presenter.render_progress(state, elapsed_s=0.0, label="queued")
+
+    row = rendered.extra["reply_markup"]["inline_keyboard"][0]
+    assert row == [
+        {"text": "steer", "callback_data": "takopi:steer"},
+        {"text": "cancel", "callback_data": "takopi:cancel"},
+    ]
 
 
 def test_telegram_presenter_final_clears_button() -> None:
@@ -514,7 +573,14 @@ async def test_telegram_transport_edit_wait_false_returns_ref() -> None:
 @pytest.mark.anyio
 async def test_handle_cancel_without_reply_prompts_user() -> None:
     transport = FakeTransport()
-    cfg = make_cfg(transport)
+    cfg = replace(
+        make_cfg(transport),
+        exec_cfg=ExecBridgeConfig(
+            transport=transport,
+            presenter=TelegramPresenter(),
+            final_notify=True,
+        ),
+    )
     msg = TelegramIncomingMessage(
         transport="telegram",
         chat_id=123,
@@ -853,6 +919,67 @@ async def test_handle_callback_cancel_cancels_queued_job() -> None:
     bot = cast(FakeBot, cfg.bot)
     assert bot.callback_calls
     assert bot.callback_calls[-1]["text"] == "dropped from queue."
+
+
+@pytest.mark.anyio
+async def test_handle_callback_steer_sends_queued_text_to_active_turn() -> None:
+    transport = FakeTransport()
+    cfg = replace(
+        make_cfg(transport),
+        exec_cfg=ExecBridgeConfig(
+            transport=transport,
+            presenter=TelegramPresenter(),
+            final_notify=True,
+        ),
+    )
+
+    async def _noop_run_job(_) -> None:
+        return None
+
+    class _Control(RunnerTurnControl):
+        def __init__(self) -> None:
+            self.steered: list[str] = []
+
+        async def steer(self, text: str) -> None:
+            self.steered.append(text)
+
+        async def interrupt(self) -> bool:
+            return True
+
+    scheduler = ThreadScheduler(task_group=_NoopTaskGroup(), run_job=_noop_run_job)
+    progress_id = 88
+    progress_ref = MessageRef(channel_id=123, message_id=progress_id)
+    resume = ResumeToken(engine=CODEX_ENGINE, value="sid")
+    await scheduler.enqueue_resume(
+        chat_id=123,
+        user_msg_id=10,
+        text="queued prompt",
+        resume_token=resume,
+        progress_ref=progress_ref,
+    )
+    control = _Control()
+    running_task = RunningTask(resume=resume, control=control)
+    running_tasks = {MessageRef(channel_id=123, message_id=7): running_task}
+    query = TelegramCallbackQuery(
+        transport="telegram",
+        chat_id=123,
+        message_id=progress_id,
+        callback_query_id="cbq-steer",
+        data="takopi:steer",
+        sender_id=123,
+    )
+
+    await telegram_loop.handle_callback_steer(cfg, query, running_tasks, scheduler)
+
+    assert control.steered == ["queued prompt"]
+    assert transport.edit_calls
+    steered_text = transport.edit_calls[0]["message"].text.lower()
+    assert "steered" in steered_text
+    assert transport.edit_calls[0]["message"].extra["reply_markup"]["inline_keyboard"] == []
+    assert await scheduler.cancel_queued(123, progress_ref.message_id) is None
+    bot = cast(FakeBot, cfg.bot)
+    assert bot.callback_calls
+    assert bot.callback_calls[-1]["text"] == "steered active turn."
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -1005,7 +1005,10 @@ async def test_handle_callback_steer_sends_queued_text_to_active_turn() -> None:
     assert transport.edit_calls
     steered_text = transport.edit_calls[0]["message"].text.lower()
     assert "steered" in steered_text
-    assert transport.edit_calls[0]["message"].extra["reply_markup"]["inline_keyboard"] == []
+    assert (
+        transport.edit_calls[0]["message"].extra["reply_markup"]["inline_keyboard"]
+        == []
+    )
     assert await scheduler.cancel_queued(123, progress_ref.message_id) is None
     bot = cast(FakeBot, cfg.bot)
     assert bot.callback_calls

--- a/tests/test_telegram_files.py
+++ b/tests/test_telegram_files.py
@@ -22,7 +22,7 @@ def test_zip_directory_skips_symlinks(tmp_path: Path) -> None:
     link_path = target / "leak.txt"
     try:
         link_path.symlink_to(outside)
-    except (OSError, NotImplementedError):
+    except OSError, NotImplementedError:
         pytest.skip("symlinks not supported")
 
     payload = zip_directory(root, Path("dir"), deny_globs=())


### PR DESCRIPTION
## Summary
- switch the Codex backend default from `codex exec --json` to a persistent `codex app-server` stdio client
- expose active-turn control so Telegram cancel uses `turn/interrupt` and queued prompts can steer the active turn
- render Codex app-server commentary in progress updates and add queued `steer | cancel` buttons

## Testing
- `uv run pytest -q --no-cov`
- `uv run ruff check src/takopi/runner.py src/takopi/runner_bridge.py src/takopi/runners/codex.py src/takopi/scheduler.py src/takopi/telegram/bridge.py src/takopi/telegram/commands/__init__.py src/takopi/telegram/commands/cancel.py src/takopi/telegram/loop.py tests/test_codex_runner_helpers.py tests/test_exec_render.py tests/test_telegram_bridge.py`
- `git diff --check`

## Notes
- Live Telegram testing confirmed `turn/steer` is accepted by app-server. Codex may still complete the original instruction depending on turn timing/model behavior.