### PR TITLE
fix(opencode): guard numeric prompts

### DIFF
--- a/src/takopi/runners/opencode.py
+++ b/src/takopi/runners/opencode.py
@@ -46,6 +46,7 @@ ENGINE: EngineId = "opencode"
 _RESUME_RE = re.compile(
     r"(?im)^\s*`?opencode(?:\s+run)?\s+(?:--session|-s)\s+(?P<token>ses_[A-Za-z0-9]+)`?\s*$"
 )
+_NUMERIC_PROMPT_RE = re.compile(r"^[0-9]+$")
 
 
 @dataclass(slots=True)
@@ -335,6 +336,8 @@ class OpenCodeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             model = run_options.model
         if model is not None:
             args.extend(["--model", str(model)])
+        if _NUMERIC_PROMPT_RE.fullmatch(prompt):
+            prompt = f"{prompt}."
         args.extend(["--", prompt])
         return args
 

--- a/tests/test_opencode_runner.py
+++ b/tests/test_opencode_runner.py
@@ -325,6 +325,20 @@ def test_build_args_with_resume() -> None:
     ]
 
 
+def test_build_args_normalizes_numeric_prompt() -> None:
+    runner = OpenCodeRunner(opencode_cmd="opencode")
+    args = runner.build_args("2", None, state=OpenCodeStreamState())
+
+    assert args[-2:] == ["--", "2."]
+
+
+def test_build_args_preserves_non_numeric_prompt() -> None:
+    runner = OpenCodeRunner(opencode_cmd="opencode")
+    args = runner.build_args("2a", None, state=OpenCodeStreamState())
+
+    assert args[-2:] == ["--", "2a"]
+
+
 def test_stdin_payload_returns_none() -> None:
     runner = OpenCodeRunner(opencode_cmd="opencode")
     payload = runner.stdin_payload("prompt", None, state=OpenCodeStreamState())


### PR DESCRIPTION
## Summary
- normalize pure numeric OpenCode prompts before passing them to the CLI
- keep non-numeric prompts unchanged
- add focused OpenCode argument-building coverage

Fixes #231.

## Tests
- uv --no-config run --locked pytest tests/test_opencode_runner.py -q --no-cov
- uv --no-config run --locked ruff check src/takopi/runners/opencode.py tests/test_opencode_runner.py
- uv --no-config run --locked ruff format --check src/takopi/runners/opencode.py tests/test_opencode_runner.py