### PR TITLE
fix(telegram): route callback commands

### DIFF
--- a/src/takopi/telegram/commands/dispatch.py
+++ b/src/takopi/telegram/commands/dispatch.py
@@ -23,6 +23,11 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _parse_callback_data(data: str) -> tuple[str, str]:
+    command_id, _, args_text = data.partition(":")
+    return command_id.lower(), args_text
+
+
 async def _dispatch_command(
     cfg: TelegramBridgeConfig,
     msg: TelegramIncomingMessage,

--- a/src/takopi/telegram/commands/handlers.py
+++ b/src/takopi/telegram/commands/handlers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .agent import _handle_agent_command as handle_agent_command
 from .dispatch import _dispatch_command as dispatch_command
+from .dispatch import _parse_callback_data as parse_callback_data
 from .executor import _run_engine as run_engine
 from .executor import _should_show_resume_line as should_show_resume_line
 from .file_transfer import _handle_file_command as handle_file_command
@@ -25,6 +26,7 @@ from .trigger import _handle_trigger_command as handle_trigger_command
 __all__ = [
     "dispatch_command",
     "get_reserved_commands",
+    "parse_callback_data",
     "handle_agent_command",
     "handle_chat_ctx_command",
     "handle_chat_new_command",

--- a/src/takopi/telegram/loop.py
+++ b/src/takopi/telegram/loop.py
@@ -50,6 +50,7 @@ from .commands.handlers import (
     handle_reasoning_command,
     handle_topic_command,
     handle_trigger_command,
+    parse_callback_data,
     parse_slash_command,
     get_reserved_commands,
     run_engine,
@@ -104,6 +105,45 @@ def _chat_session_key(
     if msg.sender_id is None:
         return None
     return (msg.chat_id, msg.sender_id)
+
+
+def _callback_message_thread_id(update: TelegramCallbackQuery) -> int | None:
+    if update.raw is None:
+        return None
+    message = update.raw.get("message")
+    if not isinstance(message, dict):
+        return None
+    thread_id = message.get("message_thread_id")
+    return thread_id if isinstance(thread_id, int) else None
+
+
+def _callback_chat_type(update: TelegramCallbackQuery) -> str | None:
+    if update.raw is None:
+        return None
+    message = update.raw.get("message")
+    if not isinstance(message, dict):
+        return None
+    chat = message.get("chat")
+    if not isinstance(chat, dict):
+        return None
+    chat_type = chat.get("type")
+    return chat_type if isinstance(chat_type, str) else None
+
+
+def _callback_message(update: TelegramCallbackQuery) -> TelegramIncomingMessage:
+    return TelegramIncomingMessage(
+        transport=update.transport,
+        chat_id=update.chat_id,
+        message_id=update.message_id,
+        text=update.data or "",
+        reply_to_message_id=None,
+        reply_to_text=None,
+        sender_id=update.sender_id,
+        thread_id=_callback_message_thread_id(update),
+        chat_type=_callback_chat_type(update),
+        raw=update.raw,
+        update_id=update.update_id,
+    )
 
 
 async def _resolve_engine_run_options(
@@ -1872,6 +1912,64 @@ async def run_main_loop(
                             state.running_tasks,
                             scheduler,
                         )
+                    elif update.data:
+                        command_id, args_text = parse_callback_data(update.data)
+                        if command_id not in state.command_ids:
+                            refresh_commands()
+                        if command_id in state.command_ids:
+                            callback_msg = _callback_message(update)
+                            ctx = await build_message_context(callback_msg)
+                            engine_resolution = await resolve_engine_defaults(
+                                explicit_engine=None,
+                                context=ctx.ambient_context,
+                                chat_id=ctx.chat_id,
+                                topic_key=ctx.topic_key,
+                            )
+                            default_engine_override = (
+                                engine_resolution.engine
+                                if engine_resolution.source
+                                in {"directive", "topic_default", "chat_default"}
+                                else None
+                            )
+                            overrides_thread_id = (
+                                ctx.topic_key[1]
+                                if ctx.topic_key is not None
+                                else callback_msg.thread_id
+                            )
+                            engine_overrides_resolver = partial(
+                                _resolve_engine_run_options,
+                                ctx.chat_id,
+                                overrides_thread_id,
+                                chat_prefs=state.chat_prefs,
+                                topic_store=state.topic_store,
+                            )
+                            tg.start_soon(
+                                cfg.bot.answer_callback_query,
+                                update.callback_query_id,
+                            )
+                            tg.start_soon(
+                                dispatch_command,
+                                cfg,
+                                callback_msg,
+                                update.data,
+                                command_id,
+                                args_text,
+                                state.running_tasks,
+                                scheduler,
+                                wrap_on_thread_known(
+                                    scheduler.note_thread_known,
+                                    ctx.topic_key,
+                                    ctx.chat_session_key,
+                                ),
+                                ctx.stateful_mode,
+                                default_engine_override,
+                                engine_overrides_resolver,
+                            )
+                        else:
+                            tg.start_soon(
+                                cfg.bot.answer_callback_query,
+                                update.callback_query_id,
+                            )
                     else:
                         tg.start_soon(
                             cfg.bot.answer_callback_query,

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -3518,6 +3518,93 @@ async def test_run_main_loop_handles_command_plugins(monkeypatch) -> None:
     assert transport.send_calls[-1]["message"].text == "echo:hello"
 
 
+def test_parse_callback_data() -> None:
+    assert telegram_loop.parse_callback_data("echo_cmd:hello world") == (
+        "echo_cmd",
+        "hello world",
+    )
+    assert telegram_loop.parse_callback_data("Echo_Cmd") == ("echo_cmd", "")
+    assert telegram_loop.parse_callback_data("echo_cmd:a:b:c") == ("echo_cmd", "a:b:c")
+
+
+@pytest.mark.anyio
+async def test_run_main_loop_routes_callback_to_command_plugins(monkeypatch) -> None:
+    seen: dict[str, Any] = {}
+
+    class _Command:
+        id = "callback_cmd"
+        description = "callback"
+
+        async def handle(self, ctx):
+            seen["text"] = ctx.text
+            seen["args"] = ctx.args
+            seen["message"] = ctx.message
+            return commands.CommandResult(text=f"callback:{ctx.args_text}")
+
+    entrypoints = [
+        FakeEntryPoint(
+            "callback_cmd",
+            "takopi.commands.callback:BACKEND",
+            plugins.COMMAND_GROUP,
+            loader=_Command,
+        )
+    ]
+    install_entrypoints(monkeypatch, entrypoints)
+
+    transport = FakeTransport()
+    bot = FakeBot()
+    runner = ScriptRunner([Return(answer="ok")], engine=CODEX_ENGINE)
+    exec_cfg = ExecBridgeConfig(
+        transport=transport,
+        presenter=MarkdownPresenter(),
+        final_notify=True,
+    )
+    runtime = TransportRuntime(
+        router=_make_router(runner),
+        projects=_empty_projects(),
+    )
+    cfg = TelegramBridgeConfig(
+        bot=bot,
+        runtime=runtime,
+        chat_id=123,
+        startup_msg="",
+        exec_cfg=exec_cfg,
+        forward_coalesce_s=FAST_FORWARD_COALESCE_S,
+        media_group_debounce_s=FAST_MEDIA_GROUP_DEBOUNCE_S,
+    )
+
+    async def poller(_cfg: TelegramBridgeConfig):
+        yield TelegramCallbackQuery(
+            transport="telegram",
+            chat_id=123,
+            message_id=42,
+            callback_query_id="cbq-1",
+            data="callback_cmd:hello world",
+            sender_id=123,
+            raw={
+                "id": "cbq-1",
+                "message": {
+                    "message_id": 42,
+                    "message_thread_id": 77,
+                    "chat": {"id": 123, "type": "private"},
+                },
+            },
+        )
+
+    await run_main_loop(cfg, poller)
+
+    assert runner.calls == []
+    assert bot.callback_calls
+    assert bot.callback_calls[-1]["callback_query_id"] == "cbq-1"
+    assert transport.send_calls[-1]["message"].text == "callback:hello world"
+    assert seen["text"] == "callback_cmd:hello world"
+    assert seen["args"] == ("hello", "world")
+    message_ref = cast(MessageRef, seen["message"])
+    assert message_ref.message_id == 42
+    assert message_ref.thread_id == 77
+    assert message_ref.sender_id == 123
+
+
 @pytest.mark.anyio
 async def test_run_main_loop_command_uses_project_default_engine(
     monkeypatch,


### PR DESCRIPTION
## Summary
- parse Telegram callback data as command backend ids using command_id:args
- route matching callback queries through the existing command dispatcher
- preserve callback message/thread context and acknowledge handled callbacks

Fixes #116.

## Tests
- uv --no-config run --locked pytest tests/test_telegram_bridge.py -q --no-cov
- uv --no-config run --locked ruff check src/takopi/telegram/commands/dispatch.py src/takopi/telegram/commands/handlers.py src/takopi/telegram/loop.py tests/test_telegram_bridge.py
- uv --no-config run --locked ruff format --check src/takopi/telegram/commands/dispatch.py src/takopi/telegram/commands/handlers.py src/takopi/telegram/loop.py tests/test_telegram_bridge.py