### PR TITLE
fix(telegram): retry network errors

### DIFF
--- a/src/takopi/telegram/client_api.py
+++ b/src/takopi/telegram/client_api.py
@@ -11,6 +11,7 @@ from .api_models import Chat, ChatMember, File, ForumTopic, Message, Update, Use
 logger = get_logger(__name__)
 
 T = TypeVar("T")
+_NETWORK_RETRY_AFTER_S = 2.0
 
 
 class RetryAfter(Exception):
@@ -203,14 +204,15 @@ class HttpBotClient:
                 )
         except httpx.HTTPError as exc:
             url = getattr(exc.request, "url", None)
+            error = str(exc) or repr(exc)
             logger.error(
                 "telegram.network_error",
                 method=method,
                 url=str(url) if url is not None else None,
-                error=str(exc),
+                error=error,
                 error_type=exc.__class__.__name__,
             )
-            return None
+            raise TelegramRetryAfter(_NETWORK_RETRY_AFTER_S, error) from exc
 
         try:
             resp.raise_for_status()
@@ -330,13 +332,14 @@ class HttpBotClient:
             resp = await self._http_client.get(url)
         except httpx.HTTPError as exc:
             request_url = getattr(exc.request, "url", None)
+            error = str(exc) or repr(exc)
             logger.error(
                 "telegram.file_network_error",
                 url=str(request_url) if request_url is not None else None,
-                error=str(exc),
+                error=error,
                 error_type=exc.__class__.__name__,
             )
-            return None
+            raise TelegramRetryAfter(_NETWORK_RETRY_AFTER_S, error) from exc
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -113,6 +113,24 @@ async def test_telegram_429_defaults_retry_after_on_bad_body() -> None:
 
 
 @pytest.mark.anyio
+async def test_telegram_network_error_raises_retry_after() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("read timed out", request=request)
+
+    transport = httpx.MockTransport(handler)
+
+    client = httpx.AsyncClient(transport=transport)
+    try:
+        api = HttpBotClient("123:abcDEF_ghij", http_client=client)
+        with pytest.raises(TelegramRetryAfter) as exc:
+            await api._post("sendMessage", {"chat_id": 1, "text": "hi"})
+    finally:
+        await client.aclose()
+
+    assert exc.value.retry_after == 2.0
+
+
+@pytest.mark.anyio
 async def test_telegram_ok_false_returns_none() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
@@ -229,4 +247,33 @@ async def test_telegram_download_file_429_defaults_retry_after_on_bad_body() -> 
 
     assert payload == b"ok"
     assert sleeps == [5.0]
+    assert len(calls) == 2
+
+
+@pytest.mark.anyio
+async def test_telegram_download_file_retries_on_network_error() -> None:
+    sleeps: list[float] = []
+
+    async def sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    calls: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(1)
+        if len(calls) == 1:
+            raise httpx.ReadTimeout("read timed out", request=request)
+        return httpx.Response(200, content=b"ok", request=request)
+
+    transport = httpx.MockTransport(handler)
+
+    client = httpx.AsyncClient(transport=transport)
+    try:
+        tg = TelegramClient("123:abcDEF_ghij", http_client=client, sleep=sleep)
+        payload = await tg.download_file("path")
+    finally:
+        await client.aclose()
+
+    assert payload == b"ok"
+    assert sleeps == [2.0]
     assert len(calls) == 2


### PR DESCRIPTION
## Summary
- raise retry signals for Telegram httpx network failures instead of returning None
- apply the same retry behavior to file downloads
- cover API request and download retry paths

Replaces #212 and fixes the same network-drop bug.

## Tests
- uv --no-config run --locked pytest tests/test_telegram_client.py -q --no-cov
- uv --no-config run --locked ruff check src/takopi/telegram/client_api.py tests/test_telegram_client.py
- uv --no-config run --locked ruff format --check src/takopi/telegram/client_api.py tests/test_telegram_client.py