### PR TITLE
fix: render context compaction nicely

### DIFF
--- a/src/takopi/runners/codex.py
+++ b/src/takopi/runners/codex.py
@@ -984,6 +984,8 @@ def _app_item_title(item: dict[str, Any]) -> str:
         return str(item.get("query") or "web search")
     if item_type == "plan":
         return str(item.get("text") or "plan")
+    if item_type == "contextCompaction":
+        return "compacting context"
     if item_type == "reasoning":
         summary = item.get("summary")
         if isinstance(summary, list) and summary:

--- a/tests/test_codex_runner_helpers.py
+++ b/tests/test_codex_runner_helpers.py
@@ -12,6 +12,7 @@ from takopi.model import ActionEvent, CompletedEvent, StartedEvent
 from takopi.runners.codex import (
     _AgentMessageSummary,
     _AppServerClient,
+    _AppServerRunState,
     AppServerCodexRunner,
     CodexRunner,
     _format_change_summary,
@@ -22,6 +23,7 @@ from takopi.runners.codex import (
     _summarize_todo_list,
     _summarize_tool_result,
     _todo_title,
+    _translate_app_item_event,
     build_runner,
     find_exec_only_flag,
     translate_codex_event,
@@ -179,6 +181,25 @@ def test_translate_codex_events_for_items() -> None:
     assert isinstance(out[0], ActionEvent)
     assert out[0].action.kind == "warning"
     assert out[0].ok is False
+
+
+def test_translate_app_server_context_compaction_item() -> None:
+    state = _AppServerRunState(factory=EventFactory("codex"))
+    item = {"id": "cc1", "type": "contextCompaction"}
+
+    out = _translate_app_item_event("item/started", item, state=state)
+    assert len(out) == 1
+    assert isinstance(out[0], ActionEvent)
+    assert out[0].phase == "started"
+    assert out[0].action.kind == "note"
+    assert out[0].action.title == "compacting context"
+
+    out = _translate_app_item_event("item/completed", item, state=state)
+    assert len(out) == 1
+    assert isinstance(out[0], ActionEvent)
+    assert out[0].phase == "completed"
+    assert out[0].ok is True
+    assert out[0].action.title == "compacting context"
 
 
 def test_translate_codex_thread_started() -> None:


### PR DESCRIPTION
## Summary
- Render Codex app-server context compaction items as `compacting context` instead of raw `contextCompaction`.
- Add app-server item translation coverage for started and completed context compaction events.

## Tests
- `uv run pytest --no-cov tests/test_codex_runner_helpers.py`
- `uv run ruff format --check src tests`
- `uv run ruff check src tests`
- `uv run pytest`

## Notes
- `uv run pytest tests/test_codex_runner_helpers.py` passes tests but fails the repo coverage gate on a focused run, as expected with total coverage only from that file.
- `uv run ty check src tests` currently reports 40 existing diagnostics unrelated to this change; the touched-file subset reports the existing `build_runner` extra_args typing diagnostics in `src/takopi/runners/codex.py`.