### PR TITLE
fix(telegram): add Claude reasoning levels

### DIFF
--- a/src/takopi/runners/claude.py
+++ b/src/takopi/runners/claude.py
@@ -311,6 +311,9 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             args.extend(["--allowedTools", allowed_tools])
         if self.dangerously_skip_permissions is True:
             args.append("--dangerously-skip-permissions")
+        if run_options is not None and run_options.reasoning:
+            args.extend(["--effort", str(run_options.reasoning)])
+            args.extend(["--settings", '{"alwaysThinkingEnabled":true}'])
         args.append("--")
         args.append(prompt)
         return args

--- a/src/takopi/runners/pi.py
+++ b/src/takopi/runners/pi.py
@@ -332,6 +332,8 @@ class PiRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             model = run_options.model
         if model:
             args.extend(["--model", model])
+        if run_options is not None and run_options.reasoning:
+            args.extend(["--thinking", str(run_options.reasoning)])
         args.extend(["--session", state.resume.value])
         args.append(self._sanitize_prompt(prompt))
         return args

--- a/src/takopi/telegram/commands/reasoning.py
+++ b/src/takopi/telegram/commands/reasoning.py
@@ -8,6 +8,7 @@ from ..engine_overrides import (
     EngineOverrides,
     allowed_reasoning_levels,
     resolve_override_value,
+    supports_reasoning,
 )
 from ..files import split_command_args
 from ..topic_state import TopicStateStore
@@ -65,6 +66,9 @@ async def _handle_reasoning_command(
         if selection is None:
             return
         engine, engine_source = selection
+        if not supports_reasoning(engine):
+            await reply(text=f"reasoning is not supported for `{engine}`.")
+            return
         topic_override = None
         if tkey is not None and topic_store is not None:
             topic_override = await topic_store.get_engine_override(
@@ -133,6 +137,9 @@ async def _handle_reasoning_command(
                     text=f"unknown engine `{engine}`.\navailable engines: `{available}`"
                 )
                 return
+        if not supports_reasoning(engine):
+            await reply(text=f"reasoning is not supported for `{engine}`.")
+            return
         normalized_level = level.strip().lower()
         allowed = allowed_reasoning_levels(engine)
         if normalized_level not in allowed:

--- a/src/takopi/telegram/engine_overrides.py
+++ b/src/takopi/telegram/engine_overrides.py
@@ -11,6 +11,7 @@ REASONING_LEVELS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh"
 REASONING_LEVELS_BY_ENGINE: dict[str, tuple[str, ...]] = {
     "claude": ("low", "medium", "high", "xhigh", "max"),
     "codex": REASONING_LEVELS,
+    "pi": REASONING_LEVELS,
 }
 REASONING_SUPPORTED_ENGINES = frozenset(REASONING_LEVELS_BY_ENGINE)
 

--- a/src/takopi/telegram/engine_overrides.py
+++ b/src/takopi/telegram/engine_overrides.py
@@ -8,7 +8,11 @@ import msgspec
 OverrideSource = Literal["topic_override", "chat_default", "default"]
 
 REASONING_LEVELS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
-REASONING_SUPPORTED_ENGINES = frozenset({"codex"})
+REASONING_LEVELS_BY_ENGINE: dict[str, tuple[str, ...]] = {
+    "claude": ("low", "medium", "high", "xhigh", "max"),
+    "codex": REASONING_LEVELS,
+}
+REASONING_SUPPORTED_ENGINES = frozenset(REASONING_LEVELS_BY_ENGINE)
 
 
 class EngineOverrides(msgspec.Struct, forbid_unknown_fields=False):
@@ -97,8 +101,7 @@ def resolve_override_value(
 
 
 def allowed_reasoning_levels(engine: str) -> tuple[str, ...]:
-    _ = engine
-    return REASONING_LEVELS
+    return REASONING_LEVELS_BY_ENGINE.get(engine, ())
 
 
 def supports_reasoning(engine: str) -> bool:

--- a/tests/test_runner_run_options.py
+++ b/tests/test_runner_run_options.py
@@ -37,6 +37,17 @@ def test_claude_run_options_override_model() -> None:
     assert args[model_idx] == "claude-opus"
 
 
+def test_claude_run_options_override_reasoning() -> None:
+    runner = ClaudeRunner(claude_cmd="claude")
+    with apply_run_options(EngineRunOptions(reasoning="xhigh")):
+        args = runner.build_args("hi", None, state=None)
+
+    assert "--effort" in args
+    assert args[args.index("--effort") + 1] == "xhigh"
+    assert "--settings" in args
+    assert args[args.index("--settings") + 1] == '{"alwaysThinkingEnabled":true}'
+
+
 def test_opencode_run_options_override_model() -> None:
     runner = OpenCodeRunner(opencode_cmd="opencode", model="claude-sonnet")
     state = OpenCodeStreamState()

--- a/tests/test_runner_run_options.py
+++ b/tests/test_runner_run_options.py
@@ -68,3 +68,14 @@ def test_pi_run_options_override_model() -> None:
     assert "--model" in args
     model_idx = args.index("--model") + 1
     assert args[model_idx] == "pi-override"
+
+
+def test_pi_run_options_override_reasoning() -> None:
+    runner = PiRunner(extra_args=[], model=None, provider=None)
+    state = PiStreamState(resume=ResumeToken(engine=PI_ENGINE, value="sess.jsonl"))
+    with apply_run_options(EngineRunOptions(reasoning="high")):
+        args = runner.build_args("hi", None, state=state)
+
+    assert "--thinking" in args
+    thinking_idx = args.index("--thinking") + 1
+    assert args[thinking_idx] == "high"

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -1686,6 +1686,93 @@ async def test_reasoning_command_show_reports_overrides(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
+async def test_reasoning_command_show_reports_claude_levels() -> None:
+    transport = FakeTransport()
+    cfg = make_cfg(transport, engine_id="claude")
+    msg = TelegramIncomingMessage(
+        transport="telegram",
+        chat_id=123,
+        message_id=10,
+        text="/reasoning",
+        reply_to_message_id=None,
+        reply_to_text=None,
+        sender_id=123,
+    )
+
+    await _handle_reasoning_command(
+        cfg,
+        msg,
+        "",
+        ambient_context=None,
+        topic_store=None,
+        chat_prefs=None,
+    )
+
+    text = transport.send_calls[-1]["message"].text
+    assert "engine: claude (global default)" in text
+    assert "available levels: low, medium, high, xhigh, max" in text
+
+
+@pytest.mark.anyio
+async def test_reasoning_command_set_max_for_claude(tmp_path: Path) -> None:
+    transport = FakeTransport()
+    cfg = make_cfg(transport, engine_id="claude")
+    chat_prefs = ChatPrefsStore(tmp_path / "telegram_chat_prefs_state.json")
+    msg = TelegramIncomingMessage(
+        transport="telegram",
+        chat_id=123,
+        message_id=10,
+        text="/reasoning set max",
+        reply_to_message_id=None,
+        reply_to_text=None,
+        sender_id=123,
+        chat_type="private",
+    )
+
+    await _handle_reasoning_command(
+        cfg,
+        msg,
+        "set max",
+        ambient_context=None,
+        topic_store=None,
+        chat_prefs=chat_prefs,
+    )
+
+    override = await chat_prefs.get_engine_override(123, "claude")
+    assert override is not None
+    assert override.reasoning == "max"
+
+
+@pytest.mark.anyio
+async def test_reasoning_command_rejects_unsupported_engine(tmp_path: Path) -> None:
+    transport = FakeTransport()
+    cfg = make_cfg(transport, engine_id="opencode")
+    chat_prefs = ChatPrefsStore(tmp_path / "telegram_chat_prefs_state.json")
+    msg = TelegramIncomingMessage(
+        transport="telegram",
+        chat_id=123,
+        message_id=10,
+        text="/reasoning set high",
+        reply_to_message_id=None,
+        reply_to_text=None,
+        sender_id=123,
+        chat_type="private",
+    )
+
+    await _handle_reasoning_command(
+        cfg,
+        msg,
+        "set high",
+        ambient_context=None,
+        topic_store=None,
+        chat_prefs=chat_prefs,
+    )
+
+    assert "not supported" in transport.send_calls[-1]["message"].text
+    assert await chat_prefs.get_engine_override(123, "opencode") is None
+
+
+@pytest.mark.anyio
 async def test_send_with_resume_waits_for_token() -> None:
     transport = FakeTransport()
     cfg = make_cfg(transport)

--- a/tests/test_telegram_engine_overrides.py
+++ b/tests/test_telegram_engine_overrides.py
@@ -26,12 +26,20 @@ def test_reasoning_levels_are_engine_specific() -> None:
         "high",
         "xhigh",
     )
+    assert allowed_reasoning_levels("pi") == (
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    )
     assert allowed_reasoning_levels("opencode") == ()
 
 
 def test_supports_reasoning_known_engines() -> None:
     assert supports_reasoning("claude") is True
     assert supports_reasoning("codex") is True
+    assert supports_reasoning("pi") is True
     assert supports_reasoning("opencode") is False
 
 

--- a/tests/test_telegram_engine_overrides.py
+++ b/tests/test_telegram_engine_overrides.py
@@ -3,10 +3,36 @@ import pytest
 from takopi.telegram.chat_prefs import ChatPrefsStore
 from takopi.telegram.engine_overrides import (
     EngineOverrides,
+    allowed_reasoning_levels,
     merge_overrides,
     resolve_override_value,
+    supports_reasoning,
 )
 from takopi.telegram.topic_state import TopicStateStore
+
+
+def test_reasoning_levels_are_engine_specific() -> None:
+    assert allowed_reasoning_levels("claude") == (
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    )
+    assert allowed_reasoning_levels("codex") == (
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    )
+    assert allowed_reasoning_levels("opencode") == ()
+
+
+def test_supports_reasoning_known_engines() -> None:
+    assert supports_reasoning("claude") is True
+    assert supports_reasoning("codex") is True
+    assert supports_reasoning("opencode") is False
 
 
 def test_merge_overrides_prefers_topic_values() -> None:


### PR DESCRIPTION
## Summary
- keep reasoning levels as a small static map in telegram engine overrides
- add Claude reasoning support with low/medium/high/xhigh/max
- add PI reasoning support with minimal/low/medium/high/xhigh via `--thinking`
- pass Telegram reasoning overrides through to supported runners
- keep OpenCode unsupported for `/reasoning` because `opencode run` has no per-run reasoning or variant flag
- reject `/reasoning` for unsupported engines before storing overrides

Supersedes #229 with a smaller implementation.

## Tests
- `uv run pytest tests/test_runner_run_options.py tests/test_telegram_engine_overrides.py tests/test_telegram_bridge.py -k reasoning --no-cov -q`
- `uv run ruff check src/takopi/runners/pi.py src/takopi/telegram/engine_overrides.py tests/test_runner_run_options.py tests/test_telegram_engine_overrides.py`
- `uv run ruff check src/takopi/runners/claude.py src/takopi/telegram/commands/reasoning.py src/takopi/telegram/engine_overrides.py tests/test_runner_run_options.py tests/test_telegram_bridge.py tests/test_telegram_engine_overrides.py`