### PR TITLE
feat(cli): add global config path override

### DIFF
--- a/src/takopi/cli/config.py
+++ b/src/takopi/cli/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-import sys
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -11,9 +10,9 @@ from pydantic import BaseModel
 
 from ..config import (
     ConfigError,
-    HOME_CONFIG_PATH,
     dump_toml,
     read_config,
+    resolve_config_path,
     write_config,
 )
 from ..config_migrations import migrate_config
@@ -45,18 +44,7 @@ def _fail_missing_config(path: Path) -> None:
 
 
 def _resolve_config_path_override(value: Path | None) -> Path:
-    if value is None:
-        return _resolve_home_config_path()
-    return value.expanduser()
-
-
-def _resolve_home_config_path() -> Path:
-    cli_module = sys.modules.get("takopi.cli")
-    if cli_module is not None:
-        override = getattr(cli_module, "HOME_CONFIG_PATH", None)
-        if override is not None:
-            return Path(override)
-    return HOME_CONFIG_PATH
+    return resolve_config_path(value)
 
 
 def _exit_config_error(exc: ConfigError, *, code: int = 2) -> None:

--- a/src/takopi/cli/run.py
+++ b/src/takopi/cli/run.py
@@ -12,7 +12,7 @@ import typer
 
 from .. import __version__
 from ..backends import EngineBackend
-from ..config import ConfigError, load_or_init_config
+from ..config import ConfigError, load_or_init_config, set_config_path_override
 from ..engines import get_backend
 from ..ids import RESERVED_CHAT_COMMANDS
 from ..lockfile import LockError, LockHandle, acquire_lock, token_fingerprint
@@ -20,7 +20,7 @@ from ..logging import get_logger, setup_logging
 from ..runtime_loader import build_runtime_spec, resolve_plugins_allowlist
 from ..settings import TakopiSettings, load_settings, load_settings_if_exists
 from ..transports import SetupResult, get_transport
-from .config import _config_path_display, _fail_missing_config
+from .config import _CONFIG_PATH_OPTION, _config_path_display, _fail_missing_config
 
 logger = get_logger(__name__)
 
@@ -331,6 +331,7 @@ def _version_callback(value: bool) -> None:
 
 def app_main(
     ctx: typer.Context,
+    config_path: Path | None = _CONFIG_PATH_OPTION,
     version: bool = typer.Option(
         False,
         "--version",
@@ -360,6 +361,9 @@ def app_main(
     ),
 ) -> None:
     """Takopi CLI."""
+    if config_path is not None:
+        previous = set_config_path_override(config_path)
+        ctx.call_on_close(lambda: set_config_path_override(previous))
     if ctx.invoked_subcommand is None:
         run_auto_router = cast(
             Callable[..., None],

--- a/src/takopi/config.py
+++ b/src/takopi/config.py
@@ -10,6 +10,23 @@ from typing import Any
 import tomli_w
 
 HOME_CONFIG_PATH = Path.home() / ".takopi" / "takopi.toml"
+_CONFIG_PATH_OVERRIDE: Path | None = None
+
+
+def set_config_path_override(path: str | Path | None) -> Path | None:
+    """Override the default config path for the current process."""
+    global _CONFIG_PATH_OVERRIDE
+    previous = _CONFIG_PATH_OVERRIDE
+    _CONFIG_PATH_OVERRIDE = None if path is None else Path(path).expanduser()
+    return previous
+
+
+def resolve_config_path(path: str | Path | None = None) -> Path:
+    if path is not None:
+        return Path(path).expanduser()
+    if _CONFIG_PATH_OVERRIDE is not None:
+        return _CONFIG_PATH_OVERRIDE
+    return HOME_CONFIG_PATH
 
 
 class ConfigError(RuntimeError):
@@ -50,7 +67,7 @@ def read_config(cfg_path: Path) -> dict:
 
 
 def load_or_init_config(path: str | Path | None = None) -> tuple[dict, Path]:
-    cfg_path = Path(path).expanduser() if path else HOME_CONFIG_PATH
+    cfg_path = resolve_config_path(path)
     if cfg_path.exists() and not cfg_path.is_file():
         raise ConfigError(f"Config path {cfg_path} exists but is not a file.") from None
     if not cfg_path.exists():

--- a/src/takopi/settings.py
+++ b/src/takopi/settings.py
@@ -20,9 +20,9 @@ from pydantic_settings.sources import TomlConfigSettingsSource
 
 from .config import (
     ConfigError,
-    HOME_CONFIG_PATH,
     ProjectConfig,
     ProjectsConfig,
+    resolve_config_path,
 )
 from .config_migrations import migrate_config_file
 
@@ -342,7 +342,7 @@ def require_telegram(settings: TakopiSettings, config_path: Path) -> tuple[str, 
 
 
 def _resolve_config_path(path: str | Path | None) -> Path:
-    return Path(path).expanduser() if path else HOME_CONFIG_PATH
+    return resolve_config_path(path)
 
 
 def _ensure_config_file(cfg_path: Path) -> None:

--- a/src/takopi/telegram/onboarding.py
+++ b/src/takopi/telegram/onboarding.py
@@ -29,12 +29,12 @@ from ..config import (
     ConfigError,
     ensure_table,
     read_config,
+    resolve_config_path,
     write_config,
 )
 from ..engines import list_backends
 from ..logging import suppress_logs
 from ..settings import (
-    HOME_CONFIG_PATH,
     TelegramTopicsSettings,
     load_settings,
     require_telegram,
@@ -197,7 +197,7 @@ def check_setup(
     transport_override: str | None = None,
 ) -> SetupResult:
     issues: list[SetupIssue] = []
-    config_path = HOME_CONFIG_PATH
+    config_path = resolve_config_path()
     cmd = backend.cli_cmd or backend.id
     backend_issues: list[SetupIssue] = []
     if shutil.which(cmd) is None:
@@ -972,7 +972,7 @@ async def run_onboarding(ui: UI, svc: Services, state: OnboardingState) -> bool:
 async def capture_chat_id(*, token: str | None = None) -> ChatInfo | None:
     ui = InteractiveUI(Console())
     svc = LiveServices()
-    state = OnboardingState(config_path=HOME_CONFIG_PATH, force=False)
+    state = OnboardingState(config_path=resolve_config_path(), force=False)
     with suppress_logging():
         try:
             if token is not None:
@@ -1008,7 +1008,7 @@ async def capture_chat_id(*, token: str | None = None) -> ChatInfo | None:
 async def interactive_setup(*, force: bool) -> bool:
     ui = InteractiveUI(Console())
     svc = LiveServices()
-    state = OnboardingState(config_path=HOME_CONFIG_PATH, force=force)
+    state = OnboardingState(config_path=resolve_config_path(), force=force)
 
     if state.config_path.exists() and not force:
         ui.print(

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -6,7 +6,8 @@ import tomllib
 from typer.testing import CliRunner
 
 from takopi import cli
-from takopi.config import ConfigError
+from takopi import config as config_module
+from takopi.config import ConfigError, resolve_config_path
 from takopi.plugins import (
     COMMAND_GROUP,
     ENGINE_GROUP,
@@ -215,13 +216,43 @@ def test_config_path_cmd_outputs_override(tmp_path: Path) -> None:
 def test_config_path_cmd_defaults_to_home(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
     config_path = tmp_path / ".takopi" / "takopi.toml"
-    monkeypatch.setattr(cli, "HOME_CONFIG_PATH", config_path)
+    monkeypatch.setattr(config_module, "HOME_CONFIG_PATH", config_path)
 
     runner = CliRunner()
     result = runner.invoke(cli.create_app(), ["config", "path"])
 
     assert result.exit_code == 0
     assert result.output.strip() == "~/.takopi/takopi.toml"
+
+
+def test_config_path_cmd_uses_global_config_path_option(tmp_path: Path) -> None:
+    config_path = tmp_path / "custom.toml"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.create_app(),
+        ["--config-path", str(config_path), "config", "path"],
+    )
+
+    assert result.exit_code == 0
+    assert result.output.strip() == str(config_path)
+
+
+def test_global_config_path_option_sets_process_override(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "custom.toml"
+    seen: dict[str, Path] = {}
+
+    def _run_auto_router(**_kwargs) -> None:
+        seen["path"] = resolve_config_path()
+
+    monkeypatch.setattr(cli, "_run_auto_router", _run_auto_router)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.create_app(), ["--config-path", str(config_path)])
+
+    assert result.exit_code == 0
+    assert seen["path"] == config_path
+    assert resolve_config_path() != config_path
 
 
 def test_doctor_rejects_non_telegram_transport(monkeypatch) -> None:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -238,7 +238,9 @@ def test_config_path_cmd_uses_global_config_path_option(tmp_path: Path) -> None:
     assert result.output.strip() == str(config_path)
 
 
-def test_global_config_path_option_sets_process_override(monkeypatch, tmp_path: Path) -> None:
+def test_global_config_path_option_sets_process_override(
+    monkeypatch, tmp_path: Path
+) -> None:
     config_path = tmp_path / "custom.toml"
     seen: dict[str, Path] = {}
 

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -4,7 +4,14 @@ from pathlib import Path
 
 import pytest
 
-from takopi.config import ConfigError, read_config, write_config
+from takopi.config import (
+    ConfigError,
+    load_or_init_config,
+    read_config,
+    resolve_config_path,
+    set_config_path_override,
+    write_config,
+)
 
 
 def test_read_write_config_round_trip(tmp_path: Path) -> None:
@@ -38,3 +45,18 @@ def test_read_config_non_file(tmp_path: Path) -> None:
     config_path.mkdir()
     with pytest.raises(ConfigError, match="exists but is not a file"):
         read_config(config_path)
+
+
+def test_config_path_override_controls_default_load(tmp_path: Path) -> None:
+    config_path = tmp_path / "custom.toml"
+    payload = {"default_engine": "codex"}
+    write_config(payload, config_path)
+
+    previous = set_config_path_override(config_path)
+    try:
+        loaded, loaded_path = load_or_init_config()
+        assert resolve_config_path() == config_path
+        assert loaded_path == config_path
+        assert loaded == payload
+    finally:
+        set_config_path_override(previous)

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -34,8 +34,9 @@ def test_check_setup_marks_missing_codex(monkeypatch, tmp_path: Path) -> None:
 
 def test_check_setup_marks_missing_config(monkeypatch, tmp_path: Path) -> None:
     backend = engines.get_backend("codex")
+    config_path = tmp_path / "takopi.toml"
     monkeypatch.setattr(onboarding.shutil, "which", lambda _name: "/usr/bin/codex")
-    monkeypatch.setattr(onboarding, "HOME_CONFIG_PATH", tmp_path / "takopi.toml")
+    monkeypatch.setattr(onboarding, "resolve_config_path", lambda: config_path)
 
     def _raise() -> None:
         raise onboarding.ConfigError("Missing config file")
@@ -46,7 +47,7 @@ def test_check_setup_marks_missing_config(monkeypatch, tmp_path: Path) -> None:
 
     titles = {issue.title for issue in result.issues}
     assert "create a config" in titles
-    assert result.config_path == onboarding.HOME_CONFIG_PATH
+    assert result.config_path == config_path
 
 
 def test_check_setup_marks_invalid_bot_token(monkeypatch, tmp_path: Path) -> None:
@@ -103,8 +104,9 @@ def test_check_setup_external_transport_missing_config(
     monkeypatch, tmp_path: Path
 ) -> None:
     backend = engines.get_backend("codex")
+    config_path = tmp_path / "takopi.toml"
     monkeypatch.setattr(onboarding.shutil, "which", lambda _name: "/usr/bin/codex")
-    monkeypatch.setattr(onboarding, "HOME_CONFIG_PATH", tmp_path / "takopi.toml")
+    monkeypatch.setattr(onboarding, "resolve_config_path", lambda: config_path)
 
     def _raise() -> None:
         raise onboarding.ConfigError("Missing config file")

--- a/tests/test_onboarding_interactive.py
+++ b/tests/test_onboarding_interactive.py
@@ -99,13 +99,13 @@ def test_interactive_setup_skips_when_config_exists(monkeypatch, tmp_path) -> No
         'bot_token = "token"\nchat_id = 123\n',
         encoding="utf-8",
     )
-    monkeypatch.setattr(onboarding, "HOME_CONFIG_PATH", config_path)
+    monkeypatch.setattr(onboarding, "resolve_config_path", lambda: config_path)
     assert anyio.run(partial(onboarding.interactive_setup, force=False)) is True
 
 
 def test_interactive_setup_writes_config(monkeypatch, tmp_path) -> None:
     config_path = tmp_path / "takopi.toml"
-    monkeypatch.setattr(onboarding, "HOME_CONFIG_PATH", config_path)
+    monkeypatch.setattr(onboarding, "resolve_config_path", lambda: config_path)
 
     backend = EngineBackend(id="codex", build_runner=lambda _cfg, _path: None)
     monkeypatch.setattr(onboarding, "list_backends", lambda: [backend])
@@ -152,7 +152,7 @@ def test_interactive_setup_preserves_projects(monkeypatch, tmp_path) -> None:
         'default_project = "z80"\n\n[projects.z80]\npath = "/tmp/repo"\n',
         encoding="utf-8",
     )
-    monkeypatch.setattr(onboarding, "HOME_CONFIG_PATH", config_path)
+    monkeypatch.setattr(onboarding, "resolve_config_path", lambda: config_path)
 
     backend = EngineBackend(id="codex", build_runner=lambda _cfg, _path: None)
     monkeypatch.setattr(onboarding, "list_backends", lambda: [backend])
@@ -188,7 +188,7 @@ def test_interactive_setup_preserves_projects(monkeypatch, tmp_path) -> None:
 
 def test_interactive_setup_no_agents_aborts(monkeypatch, tmp_path) -> None:
     config_path = tmp_path / "takopi.toml"
-    monkeypatch.setattr(onboarding, "HOME_CONFIG_PATH", config_path)
+    monkeypatch.setattr(onboarding, "resolve_config_path", lambda: config_path)
 
     backend = EngineBackend(id="codex", build_runner=lambda _cfg, _path: None)
     monkeypatch.setattr(onboarding, "list_backends", lambda: [backend])
@@ -224,7 +224,7 @@ def test_interactive_setup_recovers_from_malformed_toml(monkeypatch, tmp_path) -
     config_path = tmp_path / "takopi.toml"
     bad_toml = 'transport = "telegram"\n[transports\n'
     config_path.write_text(bad_toml, encoding="utf-8")
-    monkeypatch.setattr(onboarding, "HOME_CONFIG_PATH", config_path)
+    monkeypatch.setattr(onboarding, "resolve_config_path", lambda: config_path)
 
     backend = EngineBackend(id="codex", build_runner=lambda _cfg, _path: None)
     monkeypatch.setattr(onboarding, "list_backends", lambda: [backend])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from takopi.config import ConfigError, read_config
+from takopi.config import ConfigError, read_config, set_config_path_override
 from takopi.settings import (
     TakopiSettings,
     load_settings,
@@ -38,6 +38,29 @@ def test_load_settings_from_toml(tmp_path: Path) -> None:
     assert chat_id == 123
 
     assert settings.transports.telegram.bot_token == "token"
+
+
+def test_load_settings_uses_config_path_override(tmp_path: Path) -> None:
+    config_path = tmp_path / "custom.toml"
+    config_path.write_text(
+        'transport = "telegram"\n\n'
+        "[transports.telegram]\n"
+        'bot_token = "override-token"\n'
+        "chat_id = 456\n",
+        encoding="utf-8",
+    )
+
+    previous = set_config_path_override(config_path)
+    try:
+        settings, loaded_path = load_settings()
+    finally:
+        set_config_path_override(previous)
+
+    assert loaded_path == config_path
+    telegram = settings.transports.telegram
+    assert telegram is not None
+    assert telegram.chat_id == 456
+    assert telegram.bot_token == "override-token"
 
 
 def test_env_overrides_toml(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
**Summary**
Adds a top-level `--config-path` option so Takopi can start from a non-default config file, not just edit one through `takopi config ...`.

**Changes**
- Add shared config path resolution in `takopi.config`.
- Add top-level CLI support for `takopi --config-path PATH`.
- Route `load_settings()` and `load_or_init_config()` through the shared resolver.
- Make `takopi config ...` respect the global override as well as its existing local `--config-path`.
- Make setup/onboarding use the same resolved config path.
- Add regression tests for config loading, settings loading, config subcommands, and onboarding path behavior.

**Compatibility**
Existing behavior is preserved:
- `takopi` without `--config-path` still uses `~/.takopi/takopi.toml`.
- Existing `takopi config ... --config-path PATH` commands still work.
- Explicit API calls like `load_settings(path)` still use the explicit path.

**Validation**
- `uv run pytest --no-cov` -> `567 passed`
- `uv run ruff check ...` -> passed
- `uv run ty check ...` -> exits 0 with existing nullable warnings in older tests
- `uv run takopi --config-path /tmp/custom-takopi.toml config path` -> prints `/tmp/custom-takopi.toml`