### PR TITLE
fix: tighten loose Telegram list rendering

### DIFF
--- a/src/takopi/telegram/render.py
+++ b/src/takopi/telegram/render.py
@@ -6,6 +6,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from markdown_it import MarkdownIt
+from markdown_it.token import Token
 from sulguk import transform_html
 
 from ..markdown import MarkdownParts, assemble_markdown_parts
@@ -24,6 +25,13 @@ class _FenceState:
     fence: str
     indent: str
     header: str
+
+
+@dataclass(slots=True)
+class _ListItemState:
+    level: int
+    saw_direct_child: bool = False
+    hidden_paragraph_level: int | None = None
 
 
 def _normalize_nested_list_markers(md: str) -> str:
@@ -73,8 +81,47 @@ def _normalize_nested_list_markers(md: str) -> str:
     return "".join(lines)
 
 
+def _tighten_first_list_item_paragraphs(tokens: list[Token]) -> None:
+    item_stack: list[_ListItemState] = []
+
+    for token in tokens:
+        if token.type == "list_item_open":
+            item_stack.append(_ListItemState(level=token.level))
+            continue
+
+        if token.type == "list_item_close":
+            if item_stack:
+                item_stack.pop()
+            continue
+
+        if not item_stack:
+            continue
+
+        current = item_stack[-1]
+        if (
+            token.type == "paragraph_close"
+            and current.hidden_paragraph_level == token.level
+        ):
+            token.hidden = True
+            current.hidden_paragraph_level = None
+            continue
+
+        if token.level != current.level + 1:
+            continue
+
+        if token.type == "paragraph_open":
+            if not current.saw_direct_child:
+                token.hidden = True
+                current.hidden_paragraph_level = token.level
+            current.saw_direct_child = True
+        elif token.nesting >= 0:
+            current.saw_direct_child = True
+
+
 def render_markdown(md: str) -> tuple[str, list[dict[str, Any]]]:
-    html = _MD_RENDERER.render(_normalize_nested_list_markers(md or ""))
+    tokens = _MD_RENDERER.parse(_normalize_nested_list_markers(md or ""))
+    _tighten_first_list_item_paragraphs(tokens)
+    html = _MD_RENDERER.renderer.render(tokens, _MD_RENDERER.options, {})
     rendered = transform_html(html)
 
     text = _BULLET_RE.sub(r"\1-", rendered.text)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -38,6 +38,47 @@ def test_render_markdown_keeps_https_text_links() -> None:
     )
 
 
+def test_render_markdown_tightens_loose_ordered_list_first_paragraph() -> None:
+    text, entities = render_markdown(
+        "1. **First item** body\n\n"
+        "2. **Second item** body with `code`\n\n"
+        "3. **Third item** body\n"
+    )
+
+    assert text == (
+        "1. First item body\n2. Second item body with code\n3. Third item body\n"
+    )
+    assert entities == [
+        {"type": "bold", "offset": 3, "length": 10},
+        {"type": "bold", "offset": 22, "length": 11},
+        {"type": "code", "offset": 44, "length": 4},
+        {"type": "bold", "offset": 52, "length": 10},
+    ]
+
+
+def test_render_markdown_tightens_loose_unordered_list_first_paragraph() -> None:
+    text, entities = render_markdown(
+        "- **First item** body\n\n- **Second item** body\n"
+    )
+
+    assert text == "- First item body\n- Second item body\n"
+    assert entities == [
+        {"type": "bold", "offset": 2, "length": 10},
+        {"type": "bold", "offset": 20, "length": 11},
+    ]
+
+
+def test_render_markdown_keeps_later_loose_list_paragraphs() -> None:
+    text, _ = render_markdown(
+        "1. **First item** body\n\n   additional paragraph\n\n2. **Second item** body\n"
+    )
+
+    assert text.startswith("1. First item body\n\n")
+    assert "1.\n\n" not in text
+    assert "2.\n\n" not in text
+    assert "\xa0additional paragraph" in text
+
+
 def test_render_markdown_keeps_ordered_numbering_with_unindented_sub_bullets() -> None:
     md = (
         "1. Tune maker\n"


### PR DESCRIPTION
## Summary
- tighten the first paragraph wrapper inside Telegram-rendered list items before sulguk conversion
- add neutral regression coverage for loose ordered and unordered lists

## Tests
- uv run --frozen pytest tests/test_rendering.py -q --no-cov
- uv run --frozen ruff check src/takopi/telegram/render.py tests/test_rendering.py
- uv run --frozen pytest -q --no-cov