### PR TITLE
[codex] clarify queued cancel target

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # changelog
 
+## unreleased
+
+### fixes
+
+- make Telegram queued follow-up cancellation render as `dropped` so it is not confused with cancelling a live run [#228](https://github.com/banteg/takopi/issues/228)
+
 ## v0.23.3 (2026-05-16)
 
 ### fixes

--- a/docs/reference/specification.md
+++ b/docs/reference/specification.md
@@ -329,6 +329,10 @@ The final output MUST include:
   stop consuming the runner. Runners without turn control MUST still be aborted
   best-effort by stopping iteration and releasing held resources.
 * After cancellation, the bridge MUST stop further progress edits and publish a “cancelled” status message.
+* If `/cancel` targets a queued progress message, the bridge MUST remove that
+  queued job without interrupting the active run for the same thread.
+* A queued cancellation MUST render a terminal queued status such as `dropped`,
+  so users can distinguish it from live-run cancellation.
 * The bridge SHOULD include the ResumeLine if known.
 * Any additional text after `/cancel` is ignored.
 

--- a/docs/tutorials/first-run.md
+++ b/docs/tutorials/first-run.md
@@ -117,7 +117,7 @@ While the progress message is showing, tap the **cancel** button or reply to it 
     !!! user "You"
         /cancel
 
-Takopi sends `SIGTERM` to the agent process and posts a cancelled status:
+Takopi asks the active run to stop and posts a cancelled status:
 
 !!! failure ""
     cancelled · codex · 12s
@@ -126,8 +126,10 @@ Takopi sends `SIGTERM` to the agent process and posts a cancelled status:
 
 If a resume token was already issued (and resume lines are enabled), it will still be included so you can continue from where it stopped.
 
-!!! note "Cancel only works on progress messages"
-    If the run already finished, there's nothing to cancel. Just send a new message or reply to continue.
+!!! note "Cancel follows the progress message you target"
+    Replying to a live progress message cancels the active run. Replying to a
+    queued progress message drops only that queued follow-up; the active run for
+    the same conversation keeps going.
 
 ## 7. Try a different engine
 

--- a/src/takopi/telegram/bridge.py
+++ b/src/takopi/telegram/bridge.py
@@ -51,6 +51,13 @@ STEER_CANCEL_MARKUP = {
     ]
 }
 CLEAR_MARKUP = {"inline_keyboard": []}
+TelegramProgressControls = Literal[
+    "auto",
+    "run-cancel",
+    "queue-cancel",
+    "queue-steer-cancel",
+    "none",
+]
 
 
 class TelegramPresenter:
@@ -69,17 +76,13 @@ class TelegramPresenter:
         *,
         elapsed_s: float,
         label: str = "working",
+        controls: TelegramProgressControls = "auto",
     ) -> RenderedMessage:
         parts = self._formatter.render_progress_parts(
             state, elapsed_s=elapsed_s, label=label
         )
         text, entities = prepare_telegram(parts)
-        if _is_terminal_progress_label(label):
-            reply_markup = CLEAR_MARKUP
-        elif label.strip().lower() == "queued":
-            reply_markup = STEER_CANCEL_MARKUP
-        else:
-            reply_markup = CANCEL_MARKUP
+        reply_markup = _progress_reply_markup(label=label, controls=controls)
         return RenderedMessage(
             text=text,
             extra={"entities": entities, "reply_markup": reply_markup},
@@ -120,6 +123,22 @@ class TelegramPresenter:
         )
 
 
+def _progress_reply_markup(
+    *,
+    label: str,
+    controls: TelegramProgressControls,
+) -> dict[str, list[list[dict[str, str]]]]:
+    if controls == "none" or _is_terminal_progress_label(label):
+        return CLEAR_MARKUP
+    if controls == "queue-steer-cancel":
+        return STEER_CANCEL_MARKUP
+    if controls in {"run-cancel", "queue-cancel"}:
+        return CANCEL_MARKUP
+    if _normalized_progress_label(label) == "queued":
+        return STEER_CANCEL_MARKUP
+    return CANCEL_MARKUP
+
+
 def _normalized_progress_label(label: str) -> str:
     stripped = label.strip()
     if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
@@ -128,7 +147,7 @@ def _normalized_progress_label(label: str) -> str:
 
 
 def _is_terminal_progress_label(label: str) -> bool:
-    return _normalized_progress_label(label) in {"cancelled", "steered"}
+    return _normalized_progress_label(label) in {"cancelled", "dropped", "steered"}
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/takopi/telegram/commands/cancel.py
+++ b/src/takopi/telegram/commands/cancel.py
@@ -45,7 +45,7 @@ async def handle_cancel(
                     progress_message_id=reply_id,
                     resume=job.resume_token.value,
                 )
-                await _edit_cancelled_message(cfg, progress_ref, job)
+                await _edit_dropped_message(cfg, progress_ref, job)
                 return
         await reply(text="nothing is currently running for that message.")
         return
@@ -76,10 +76,10 @@ async def handle_callback_cancel(
                     progress_message_id=query.message_id,
                     resume=job.resume_token.value,
                 )
-                await _edit_cancelled_message(cfg, progress_ref, job)
+                await _edit_dropped_message(cfg, progress_ref, job)
                 await cfg.bot.answer_callback_query(
                     callback_query_id=query.callback_query_id,
-                    text="dropped from queue.",
+                    text="dropped queued follow-up.",
                 )
                 return
         await cfg.bot.answer_callback_query(
@@ -166,12 +166,12 @@ async def handle_callback_steer(
     )
 
 
-async def _edit_cancelled_message(
+async def _edit_dropped_message(
     cfg: TelegramBridgeConfig,
     progress_ref: MessageRef,
     job: ThreadJob,
 ) -> None:
-    await _edit_labelled_message(cfg, progress_ref, job, label="cancelled")
+    await _edit_labelled_message(cfg, progress_ref, job, label="dropped")
 
 
 async def _edit_labelled_message(

--- a/src/takopi/telegram/loop.py
+++ b/src/takopi/telegram/loop.py
@@ -28,6 +28,7 @@ from .bridge import (
     CANCEL_CALLBACK_DATA,
     STEER_CALLBACK_DATA,
     TelegramBridgeConfig,
+    TelegramPresenter,
     send_plain,
 )
 from .commands.cancel import (
@@ -929,11 +930,19 @@ async def _send_queued_progress(
         resume_formatter=resume_formatter,
         context_line=context_line,
     )
-    message = cfg.exec_cfg.presenter.render_progress(
-        state,
-        elapsed_s=0.0,
-        label="queued" if steerable else "starting",
-    )
+    if isinstance(cfg.exec_cfg.presenter, TelegramPresenter):
+        message = cfg.exec_cfg.presenter.render_progress(
+            state,
+            elapsed_s=0.0,
+            label="queued",
+            controls="queue-steer-cancel" if steerable else "queue-cancel",
+        )
+    else:
+        message = cfg.exec_cfg.presenter.render_progress(
+            state,
+            elapsed_s=0.0,
+            label="queued",
+        )
     reply_ref = MessageRef(
         channel_id=chat_id,
         message_id=user_msg_id,

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -316,6 +316,33 @@ def test_telegram_presenter_progress_shows_steer_button_for_queued() -> None:
     ]
 
 
+def test_telegram_presenter_progress_shows_cancel_only_for_queue_cancel() -> None:
+    presenter = TelegramPresenter()
+    state = ProgressTracker(engine="codex").snapshot()
+
+    rendered = presenter.render_progress(
+        state,
+        elapsed_s=0.0,
+        label="queued",
+        controls="queue-cancel",
+    )
+
+    assert rendered.text.lower().startswith("queued")
+    assert rendered.extra["reply_markup"]["inline_keyboard"] == [
+        [{"text": "cancel", "callback_data": "takopi:cancel"}]
+    ]
+
+
+def test_telegram_presenter_dropped_clears_buttons() -> None:
+    presenter = TelegramPresenter()
+    state = ProgressTracker(engine="codex").snapshot()
+
+    rendered = presenter.render_progress(state, elapsed_s=0.0, label="dropped")
+
+    assert rendered.text.lower().startswith("dropped")
+    assert rendered.extra["reply_markup"]["inline_keyboard"] == []
+
+
 @pytest.mark.anyio
 async def test_send_queued_progress_omits_steer_when_not_steerable() -> None:
     transport = FakeTransport()
@@ -340,9 +367,42 @@ async def test_send_queued_progress_omits_steer_when_not_steerable() -> None:
 
     assert transport.send_calls
     message = transport.send_calls[0]["message"]
-    assert message.text.lower().startswith("starting")
+    assert message.text.lower().startswith("queued")
     assert message.extra["reply_markup"]["inline_keyboard"] == [
         [{"text": "cancel", "callback_data": "takopi:cancel"}]
+    ]
+
+
+@pytest.mark.anyio
+async def test_send_queued_progress_shows_steer_when_steerable() -> None:
+    transport = FakeTransport()
+    cfg = replace(
+        make_cfg(transport),
+        exec_cfg=ExecBridgeConfig(
+            transport=transport,
+            presenter=TelegramPresenter(),
+            final_notify=True,
+        ),
+    )
+
+    await telegram_loop._send_queued_progress(
+        cfg,
+        chat_id=123,
+        user_msg_id=10,
+        thread_id=None,
+        resume_token=ResumeToken(engine=CODEX_ENGINE, value="sid"),
+        context=None,
+        steerable=True,
+    )
+
+    assert transport.send_calls
+    message = transport.send_calls[0]["message"]
+    assert message.text.lower().startswith("queued")
+    assert message.extra["reply_markup"]["inline_keyboard"] == [
+        [
+            {"text": "steer", "callback_data": "takopi:steer"},
+            {"text": "cancel", "callback_data": "takopi:cancel"},
+        ]
     ]
 
 
@@ -754,7 +814,7 @@ async def test_handle_cancel_cancels_queued_job() -> None:
 
     assert transport.edit_calls
     cancelled_text = transport.edit_calls[0]["message"].text.lower()
-    assert "cancelled" in cancelled_text
+    assert cancelled_text.startswith("dropped")
     assert "codex resume sid" in cancelled_text
     assert await scheduler.cancel_queued(123, progress_ref.message_id) is None
 
@@ -944,11 +1004,11 @@ async def test_handle_callback_cancel_cancels_queued_job() -> None:
 
     assert transport.edit_calls
     cancelled_text = transport.edit_calls[0]["message"].text.lower()
-    assert "cancelled" in cancelled_text
+    assert cancelled_text.startswith("dropped")
     assert "codex resume sid" in cancelled_text
     bot = cast(FakeBot, cfg.bot)
     assert bot.callback_calls
-    assert bot.callback_calls[-1]["text"] == "dropped from queue."
+    assert bot.callback_calls[-1]["text"] == "dropped queued follow-up."
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Render queued Telegram continuation placeholders as `queued` and keep steer/cancel controls explicit.
- Render queued follow-up cancellation as terminal `dropped` instead of `cancelled` so it is not confused with interrupting a live run.
- Update tests, specification, tutorial docs, and changelog for issue #228.

## Why
Issue #228 reported a confusing state where `/cancel` logged `cancel.queued` while an older Codex run remained live. The routing was plausible, but the UI made queued follow-up cancellation too easy to mistake for live-run cancellation.

## Test Plan
- `uv run pytest tests/test_telegram_bridge.py -q --no-cov`
- `uv run pytest -q --no-cov`
- `uv run ruff check src/takopi/telegram/bridge.py src/takopi/telegram/loop.py src/takopi/telegram/commands/cancel.py tests/test_telegram_bridge.py`
- `uv run ruff format --check src/takopi/telegram/bridge.py src/takopi/telegram/loop.py src/takopi/telegram/commands/cancel.py tests/test_telegram_bridge.py`
- `git diff --check`