### PR TITLE
fix(claude): reset oversized sessions before resuming

### DIFF
--- a/src/takopi/runners/claude.py
+++ b/src/takopi/runners/claude.py
@@ -5,6 +5,7 @@ import re
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
+from collections.abc import AsyncIterator
 from typing import Any
 
 import msgspec
@@ -324,6 +325,9 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
     use_api_billing: bool = False
     session_title: str = "claude"
     logger = logger
+    # Internal flag: set when a session reset is pending so new_state can
+    # mark the resulting ClaudeStreamState and inject a user-facing note.
+    _pending_session_reset: bool = field(default=False, init=False)
 
     def format_resume(self, token: ResumeToken) -> str:
         if token.engine != ENGINE:
@@ -355,24 +359,34 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
     def command(self) -> str:
         return self.claude_cmd
 
-    def build_args(
-        self,
-        prompt: str,
-        resume: ResumeToken | None,
-        *,
-        state: ClaudeStreamState,
-    ) -> list[str]:
+    async def run_impl(
+        self, prompt: str, resume: ResumeToken | None
+    ) -> AsyncIterator[TakopiEvent]:
         if _session_over_limit(resume):
             assert resume is not None
-            size_mb = (_find_session_file(resume.value) or Path()).stat().st_size / (1024 * 1024)
+            path = _find_session_file(resume.value)
+            size_mb = path.stat().st_size / (1024 * 1024) if path else 0.0
             logger.info(
                 "claude.session_reset",
                 session_id=resume.value,
                 size_mb=round(size_mb, 1),
                 threshold_mb=_SESSION_RESET_BYTES / (1024 * 1024),
             )
-            state.session_was_reset = True
+            # Clear resume before super() sets JsonlStreamState.expected_session;
+            # otherwise the new session ID emitted by Claude triggers a mismatch
+            # error ("emitted session id X but expected Y").
+            self._pending_session_reset = True
             resume = None
+        async for evt in super().run_impl(prompt, resume):
+            yield evt
+
+    def build_args(
+        self,
+        prompt: str,
+        resume: ResumeToken | None,
+        *,
+        state: Any,
+    ) -> list[str]:
         return self._build_args(prompt, resume)
 
     def stdin_payload(
@@ -392,7 +406,11 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         return None
 
     def new_state(self, prompt: str, resume: ResumeToken | None) -> ClaudeStreamState:
-        return ClaudeStreamState()
+        state = ClaudeStreamState()
+        if self._pending_session_reset:
+            state.session_was_reset = True
+            self._pending_session_reset = False
+        return state
 
     def start_run(
         self,

--- a/src/takopi/runners/claude.py
+++ b/src/takopi/runners/claude.py
@@ -12,7 +12,7 @@ import msgspec
 from ..backends import EngineBackend, EngineConfig
 from ..events import EventFactory
 from ..logging import get_logger
-from ..model import Action, ActionKind, EngineId, ResumeToken, TakopiEvent
+from ..model import Action, ActionKind, EngineId, ResumeToken, StartedEvent, TakopiEvent
 from ..runner import JsonlSubprocessRunner, ResumeTokenMixin, Runner
 from .run_options import get_run_options
 from ..schemas import claude as claude_schema
@@ -27,6 +27,39 @@ _RESUME_RE = re.compile(
     r"(?im)^\s*`?claude\s+(?:--resume|-r)\s+(?P<token>[^`\s]+)`?\s*$"
 )
 
+# Sessions larger than this will be dropped and restarted before the run so
+# that Claude's per-message process model doesn't load a context that already
+# exceeds the window.  2 MB is a conservative proxy; adjust via the
+# TAKOPI_CLAUDE_SESSION_RESET_MB environment variable.
+_DEFAULT_SESSION_RESET_MB = 2.0
+_SESSION_RESET_BYTES = int(
+    float(os.environ.get("TAKOPI_CLAUDE_SESSION_RESET_MB", _DEFAULT_SESSION_RESET_MB))
+    * 1024
+    * 1024
+)
+
+_CONTEXT_OVERFLOW_PHRASES = (
+    "Usage credits required for 1M context",
+    "Prompt is too long",
+)
+
+
+def _find_session_file(session_id: str) -> Path | None:
+    """Search ~/.claude/projects recursively for a session JSONL by ID."""
+    projects = Path.home() / ".claude" / "projects"
+    if not projects.exists():
+        return None
+    for path in projects.rglob(f"{session_id}.jsonl"):
+        return path
+    return None
+
+
+def _session_over_limit(resume: ResumeToken | None) -> bool:
+    if resume is None or _SESSION_RESET_BYTES <= 0:
+        return False
+    path = _find_session_file(resume.value)
+    return path is not None and path.stat().st_size > _SESSION_RESET_BYTES
+
 
 @dataclass(slots=True)
 class ClaudeStreamState:
@@ -34,6 +67,7 @@ class ClaudeStreamState:
     pending_actions: dict[str, Action] = field(default_factory=dict)
     last_assistant_text: str | None = None
     note_seq: int = 0
+    session_was_reset: bool = False
 
 
 def _normalize_tool_result(content: Any) -> str:
@@ -326,8 +360,19 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         prompt: str,
         resume: ResumeToken | None,
         *,
-        state: Any,
+        state: ClaudeStreamState,
     ) -> list[str]:
+        if _session_over_limit(resume):
+            assert resume is not None
+            size_mb = (_find_session_file(resume.value) or Path()).stat().st_size / (1024 * 1024)
+            logger.info(
+                "claude.session_reset",
+                session_id=resume.value,
+                size_mb=round(size_mb, 1),
+                threshold_mb=_SESSION_RESET_BYTES / (1024 * 1024),
+            )
+            state.session_was_reset = True
+            resume = None
         return self._build_args(prompt, resume)
 
     def stdin_payload(
@@ -405,12 +450,24 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         resume: ResumeToken | None,
         found_session: ResumeToken | None,
     ) -> list[TakopiEvent]:
-        return translate_claude_event(
+        events = translate_claude_event(
             data,
             title=self.session_title,
             state=state,
             factory=state.factory,
         )
+        if state.session_was_reset and any(isinstance(e, StartedEvent) for e in events):
+            state.session_was_reset = False
+            state.note_seq += 1
+            reset_note = state.factory.action_completed(
+                action_id=f"claude.session_reset.{state.note_seq}",
+                kind="note",
+                title="session was too large and has been reset",
+                ok=True,
+                detail={},
+            )
+            return [reset_note, *events]
+        return events
 
     def process_error_events(
         self,

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -11,6 +11,8 @@ from takopi.runners.claude import (
     ClaudeRunner,
     ClaudeStreamState,
     ENGINE,
+    _SESSION_RESET_BYTES,
+    _session_over_limit,
     translate_claude_event,
 )
 from takopi.schemas import claude as claude_schema
@@ -423,3 +425,147 @@ async def test_run_strips_anthropic_api_key_by_default(tmp_path, monkeypatch) ->
         if isinstance(event, CompletedEvent):
             answer = event.answer
     assert answer == "api=set"
+
+
+# ── session reset tests ────────────────────────────────────────────────────────
+
+
+def test_session_over_limit_none_resume() -> None:
+    assert _session_over_limit(None) is False
+
+
+def test_session_over_limit_missing_file() -> None:
+    token = ResumeToken(engine=ENGINE, value="nonexistent-session-id")
+    assert _session_over_limit(token) is False
+
+
+def test_session_over_limit_small_file(tmp_path, monkeypatch) -> None:
+    session_id = "small-session-id"
+    projects = tmp_path / ".claude" / "projects" / "test"
+    projects.mkdir(parents=True)
+    (projects / f"{session_id}.jsonl").write_bytes(b"x" * 100)
+
+    monkeypatch.setattr(claude_runner, "_find_session_file", lambda sid: (projects / f"{sid}.jsonl") if (projects / f"{sid}.jsonl").exists() else None)
+
+    token = ResumeToken(engine=ENGINE, value=session_id)
+    assert _session_over_limit(token) is False
+
+
+def test_session_over_limit_large_file(tmp_path, monkeypatch) -> None:
+    session_id = "large-session-id"
+    projects = tmp_path / ".claude" / "projects" / "test"
+    projects.mkdir(parents=True)
+    (projects / f"{session_id}.jsonl").write_bytes(b"x" * (_SESSION_RESET_BYTES + 1))
+
+    monkeypatch.setattr(claude_runner, "_find_session_file", lambda sid: (projects / f"{sid}.jsonl") if (projects / f"{sid}.jsonl").exists() else None)
+
+    token = ResumeToken(engine=ENGINE, value=session_id)
+    assert _session_over_limit(token) is True
+
+
+def test_new_state_transfers_pending_reset_flag() -> None:
+    runner = ClaudeRunner(claude_cmd="claude")
+    runner._pending_session_reset = True
+    state = runner.new_state("hello", None)
+    assert state.session_was_reset is True
+    assert runner._pending_session_reset is False
+
+
+def test_new_state_no_reset_flag_by_default() -> None:
+    runner = ClaudeRunner(claude_cmd="claude")
+    state = runner.new_state("hello", None)
+    assert state.session_was_reset is False
+
+
+def test_translate_injects_reset_note_on_started_event() -> None:
+    runner = ClaudeRunner(claude_cmd="claude")
+    state = ClaudeStreamState()
+    state.session_was_reset = True
+
+    init_event = _decode_event({
+        "type": "system",
+        "subtype": "init",
+        "session_id": "new-session-id",
+        "apiKeySource": "env",
+        "cwd": ".",
+        "tools": [],
+        "mcp_servers": [],
+        "model": "claude",
+        "permissionMode": "default",
+        "slash_commands": [],
+        "output_style": "default",
+    })
+
+    events = runner.translate(
+        init_event,
+        state=state,
+        resume=None,
+        found_session=None,
+    )
+
+    assert len(events) == 2
+    note, started = events
+    assert isinstance(note, ActionEvent)
+    assert note.action.kind == "note"
+    assert "reset" in note.action.title
+    assert isinstance(started, StartedEvent)
+    assert state.session_was_reset is False
+
+
+@pytest.mark.anyio
+async def test_run_impl_resets_oversized_session(tmp_path, monkeypatch) -> None:
+    """run_impl must drop --resume and avoid expected_session mismatch when the
+    session file exceeds the size threshold."""
+    old_session_id = "old-session-aabbccdd"
+    new_session_id = "new-session-11223344"
+
+    projects = tmp_path / ".claude" / "projects" / "test"
+    projects.mkdir(parents=True)
+    session_file = projects / f"{old_session_id}.jsonl"
+    session_file.write_bytes(b"x" * (_SESSION_RESET_BYTES + 1))
+
+    monkeypatch.setattr(
+        claude_runner,
+        "_find_session_file",
+        lambda sid: session_file if sid == old_session_id else None,
+    )
+
+    claude_path = tmp_path / "claude"
+    claude_path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        f"session_id = '{new_session_id}'\n"
+        "# Verify --resume was NOT passed (session was reset)\n"
+        "assert '--resume' not in sys.argv, f'unexpected --resume in {sys.argv}'\n"
+        "init = {'type': 'system', 'subtype': 'init', 'uuid': 'u',\n"
+        "        'session_id': session_id, 'apiKeySource': 'env', 'cwd': '.',\n"
+        "        'tools': [], 'mcp_servers': [], 'model': 'claude',\n"
+        "        'permissionMode': 'default', 'slash_commands': [],\n"
+        "        'output_style': 'default'}\n"
+        "result = {'type': 'result', 'subtype': 'success', 'uuid': 'u',\n"
+        "          'session_id': session_id, 'duration_ms': 0,\n"
+        "          'duration_api_ms': 0, 'is_error': False, 'num_turns': 1,\n"
+        "          'result': 'ok', 'total_cost_usd': 0.0,\n"
+        "          'usage': {'input_tokens': 0, 'output_tokens': 0},\n"
+        "          'modelUsage': {}, 'permission_denials': []}\n"
+        "print(json.dumps(init), flush=True)\n"
+        "print(json.dumps(result), flush=True)\n",
+        encoding="utf-8",
+    )
+    claude_path.chmod(0o755)
+
+    runner = ClaudeRunner(claude_cmd=str(claude_path))
+    resume = ResumeToken(engine=ENGINE, value=old_session_id)
+
+    events: list = []
+    async for evt in runner.run("hello", resume):
+        events.append(evt)
+
+    # Should complete without raising "emitted session id X but expected Y"
+    completed = next(e for e in events if isinstance(e, CompletedEvent))
+    assert completed.ok is True
+    assert completed.resume == ResumeToken(engine=ENGINE, value=new_session_id)
+
+    # Reset note should have been injected
+    notes = [e for e in events if isinstance(e, ActionEvent) and e.action.kind == "note" and "reset" in e.action.title]
+    assert len(notes) == 1


### PR DESCRIPTION
## Thinking path

- Takopi uses a per-message process model: each turn spawns \`claude -p\` and passes \`--resume <session_id>\`
- Claude Code loads the full session context at startup before it can auto-compact
- Once a session JSONL grows past the model's context window, every subsequent message fails immediately — before a single token is processed
- There is no recovery path: the session is permanently stuck until manually cleared
- This fix adds a proactive size check before passing \`--resume\`, so Takopi resets the session itself rather than letting Claude fail

Closes #133

## What changed

All changes are in \`src/takopi/runners/claude.py\` and \`tests/test_claude_runner.py\`.

**New helpers**
- \`_find_session_file(session_id)\` — locates a session JSONL under \`~/.claude/projects/\` by ID
- \`_session_over_limit(resume)\` — returns \`True\` if the file exceeds the byte threshold
- Threshold defaults to 2 MB, tunable via \`TAKOPI_CLAUDE_SESSION_RESET_MB\` env var (set to \`0\` to disable)

**\`ClaudeRunner\` changes**
- \`_pending_session_reset: bool\` field (slots-compatible, not exposed in \`__init__\`)
- \`run_impl\` override: checks size **before** calling \`super().run_impl()\`, which is where \`JsonlStreamState(expected_session=resume)\` is set. Passing \`resume=None\` means \`expected_session=None\`, so no mismatch error fires
- \`new_state\` override: transfers \`_pending_session_reset\` flag onto \`ClaudeStreamState.session_was_reset\`
- \`translate\` override: injects a \`"session was too large and has been reset"\` note event on the first \`StartedEvent\` of the new session

## Why \`run_impl\` and not \`build_args\`

The first implementation used \`build_args\` to drop the resume token. This caused a secondary error:

> \`claude emitted session id 965884e7 but expected f397bc82\`

\`JsonlStreamState.expected_session\` is set from \`resume\` inside \`super().run_impl()\` **before** \`build_args\` is called. Dropping the token in \`build_args\` cleared it from the subprocess args but not from \`expected_session\`. Moving the check to \`run_impl\` fixes both issues in one place.

## Before / after

**Before:** sending a message when a session exceeds the context window  
```
error · claude · 4s
API Error: Usage credits required for 1M context · turn on usage credits at claude.ai/settings/usage, or use --model to switch to standard context
```
Every subsequent message produces the same error. Manual intervention required.

**After:** Takopi detects the oversized session before spawning Claude, resets it, and tells the user  
```
⚠ session was too large and has been reset
● working ...
[normal response]
```

## Tests

8 new tests in \`tests/test_claude_runner.py\`:
- \`test_session_over_limit_*\` — unit tests for the size guard (None resume, missing file, small file, large file)
- \`test_new_state_transfers_pending_reset_flag\` / \`test_new_state_no_reset_flag_by_default\`
- \`test_translate_injects_reset_note_on_started_event\`
- \`test_run_impl_resets_oversized_session\` — async integration test using a fake \`claude\` binary; asserts \`--resume\` is not passed, no session ID mismatch error fires, reset note is emitted, and the run completes successfully

All 17 tests in \`test_claude_runner.py\` pass. Ruff and ty checks clean.

## Model used

Claude Sonnet 4.6 (\`claude-sonnet-4-6\`) via Claude Code. The fix was developed iteratively — the \`build_args\` approach was written first, the \`expected_session\` mismatch was caught during live testing on a real Takopi VM, and the implementation was moved to \`run_impl\` to address the root cause.