### PR TITLE
fix(telegram): treat editMessageText "message is not modified" as a no-op

### DIFF
--- a/src/takopi/telegram/bridge.py
+++ b/src/takopi/telegram/bridge.py
@@ -18,7 +18,7 @@ from ..settings import (
     TelegramTopicsSettings,
     TelegramTransportSettings,
 )
-from .client import BotClient
+from .client import BotClient, MessageUnchanged
 from .render import MAX_BODY_CHARS, prepare_telegram, prepare_telegram_multi
 from .types import TelegramCallbackQuery, TelegramIncomingMessage
 
@@ -282,6 +282,10 @@ class TelegramTransport:
         )
         if edited is None:
             return ref if not wait else None
+        if isinstance(edited, MessageUnchanged):
+            # the message already reads the way we wanted; sending a fresh one
+            # instead would just duplicate it
+            return ref
         if followups:
             reply_to_message_id = cast(
                 int | None, message.extra.get("followup_reply_to_message_id")

--- a/src/takopi/telegram/client.py
+++ b/src/takopi/telegram/client.py
@@ -10,7 +10,14 @@ import httpx
 
 from ..logging import get_logger
 from .api_models import Chat, ChatMember, File, ForumTopic, Message, Update, User
-from .client_api import BotClient, HttpBotClient, TelegramRetryAfter
+from .client_api import (
+    MESSAGE_UNCHANGED,
+    BotClient,
+    EditResult,
+    HttpBotClient,
+    MessageUnchanged,
+    TelegramRetryAfter,
+)
 from .outbox import (
     DELETE_PRIORITY,
     EDIT_PRIORITY,
@@ -23,7 +30,10 @@ from .parsing import parse_incoming_update, poll_incoming
 logger = get_logger(__name__)
 
 __all__ = [
+    "MESSAGE_UNCHANGED",
     "BotClient",
+    "EditResult",
+    "MessageUnchanged",
     "TelegramClient",
     "TelegramRetryAfter",
     "is_group_chat_id",
@@ -246,8 +256,8 @@ class TelegramClient:
         reply_markup: dict[str, Any] | None = None,
         *,
         wait: bool = True,
-    ) -> Message | None:
-        async def execute() -> Message | None:
+    ) -> EditResult:
+        async def execute() -> EditResult:
             return await self._client.edit_message_text(
                 chat_id=chat_id,
                 message_id=message_id,

--- a/src/takopi/telegram/client_api.py
+++ b/src/takopi/telegram/client_api.py
@@ -25,6 +25,22 @@ class TelegramRetryAfter(RetryAfter):
     pass
 
 
+class MessageUnchanged:
+    """An edit that Telegram rejected because nothing about the message changed.
+
+    Distinct from `None` (a real failure): the message is already in the
+    requested state, so callers should treat it as a successful no-op rather
+    than retrying or falling back to sending a new message.
+    """
+
+
+MESSAGE_UNCHANGED = MessageUnchanged()
+
+EditResult = Message | MessageUnchanged | None
+
+_NOT_MODIFIED = "message is not modified"
+
+
 def retry_after_from_payload(payload: dict[str, Any]) -> float | None:
     params = payload.get("parameters")
     if isinstance(params, dict):
@@ -83,7 +99,7 @@ class BotClient(Protocol):
         reply_markup: dict[str, Any] | None = None,
         *,
         wait: bool = True,
-    ) -> Message | None: ...
+    ) -> EditResult: ...
 
     async def delete_message(
         self,
@@ -192,6 +208,7 @@ class HttpBotClient:
         json: dict[str, Any] | None = None,
         data: dict[str, Any] | None = None,
         files: dict[str, Any] | None = None,
+        benign_400: str | None = None,
     ) -> Any | None:
         request_payload = json if json is not None else data
         logger.debug("telegram.request", method=method, payload=request_payload)
@@ -235,6 +252,13 @@ class HttpBotClient:
                 )
                 raise TelegramRetryAfter(retry_after) from exc
             body = resp.text
+            if (
+                benign_400 is not None
+                and resp.status_code == 400
+                and benign_400 in body
+            ):
+                logger.debug("telegram.benign_400", method=method, body=body)
+                return MESSAGE_UNCHANGED
             logger.error(
                 "telegram.http_error",
                 method=method,
@@ -286,8 +310,14 @@ class HttpBotClient:
             )
             return None
 
-    async def _post(self, method: str, json_data: dict[str, Any]) -> Any | None:
-        return await self._request(method, json=json_data)
+    async def _post(
+        self,
+        method: str,
+        json_data: dict[str, Any],
+        *,
+        benign_400: str | None = None,
+    ) -> Any | None:
+        return await self._request(method, json=json_data, benign_400=benign_400)
 
     async def _post_form(
         self,
@@ -437,7 +467,7 @@ class HttpBotClient:
         reply_markup: dict[str, Any] | None = None,
         *,
         wait: bool = True,
-    ) -> Message | None:
+    ) -> EditResult:
         params: dict[str, Any] = {
             "chat_id": chat_id,
             "message_id": message_id,
@@ -450,7 +480,9 @@ class HttpBotClient:
         params["link_preview_options"] = {"is_disabled": True}
         if reply_markup is not None:
             params["reply_markup"] = reply_markup
-        result = await self._post("editMessageText", params)
+        result = await self._post("editMessageText", params, benign_400=_NOT_MODIFIED)
+        if result is MESSAGE_UNCHANGED:
+            return MESSAGE_UNCHANGED
         return self._decode_result(
             method="editMessageText",
             payload=result,

--- a/tests/telegram_fakes.py
+++ b/tests/telegram_fakes.py
@@ -17,7 +17,7 @@ from takopi.telegram.api_models import (
     User,
 )
 from takopi.telegram.bridge import TelegramBridgeConfig
-from takopi.telegram.client import BotClient
+from takopi.telegram.client import BotClient, EditResult
 from takopi.transport import MessageRef, RenderedMessage, SendOptions
 from takopi.transport_runtime import TransportRuntime
 
@@ -93,6 +93,8 @@ class FakeBot(BotClient):
         self.send_calls: list[dict] = []
         self.document_calls: list[dict] = []
         self.edit_calls: list[dict] = []
+        # set to MESSAGE_UNCHANGED to simulate a "message is not modified" 400
+        self.edit_result: EditResult | None = None
         self.edit_topic_calls: list[dict[str, Any]] = []
         self.delete_calls: list[dict] = []
 
@@ -176,7 +178,7 @@ class FakeBot(BotClient):
         reply_markup: dict | None = None,
         *,
         wait: bool = True,
-    ) -> Message:
+    ) -> EditResult:
         self.edit_calls.append(
             {
                 "chat_id": chat_id,
@@ -188,6 +190,8 @@ class FakeBot(BotClient):
                 "wait": wait,
             }
         )
+        if self.edit_result is not None:
+            return self.edit_result
         return Message(message_id=message_id, chat=Chat(id=chat_id, type="private"))
 
     async def delete_message(self, chat_id: int, message_id: int) -> bool:

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -27,7 +27,7 @@ from takopi.telegram.bridge import (
     run_main_loop,
     send_with_resume,
 )
-from takopi.telegram.client import BotClient
+from takopi.telegram.client import MESSAGE_UNCHANGED, BotClient
 from takopi.telegram.render import MAX_BODY_CHARS
 from takopi.telegram.topic_state import TopicStateStore, resolve_state_path
 from takopi.telegram.chat_sessions import ChatSessionStore, resolve_sessions_path
@@ -440,6 +440,21 @@ async def test_telegram_transport_sends_followups() -> None:
     assert bot.send_calls[1]["message_thread_id"] == 7
     assert bot.send_calls[1]["replace_message_id"] is None
     assert bot.send_calls[1]["disable_notification"] is True
+
+
+@pytest.mark.anyio
+async def test_telegram_transport_edit_unchanged_keeps_ref_without_resending() -> None:
+    bot = FakeBot()
+    bot.edit_result = MESSAGE_UNCHANGED
+    transport = TelegramTransport(bot)
+    ref = MessageRef(channel_id=123, message_id=42, thread_id=7)
+
+    edited = await transport.edit(ref=ref, message=RenderedMessage(text="same"))
+
+    # a duplicate post would be the alternative: _send_or_edit_message falls
+    # through to send whenever edit returns None
+    assert edited == ref
+    assert not bot.send_calls
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_client_api.py
+++ b/tests/test_telegram_client_api.py
@@ -2,11 +2,12 @@ import httpx
 import pytest
 
 from takopi.telegram.client_api import (
+    MESSAGE_UNCHANGED,
     HttpBotClient,
     TelegramRetryAfter,
     retry_after_from_payload,
 )
-from takopi.telegram.api_models import User
+from takopi.telegram.api_models import Message, User
 
 
 def _response() -> httpx.Response:
@@ -96,7 +97,9 @@ async def test_client_methods_build_params_and_decode() -> None:
             json: dict | None = None,
             data: dict | None = None,
             files: dict | None = None,
+            benign_400: str | None = None,
         ) -> object | None:
+            _ = benign_400
             self.calls.append((method, json, data, files))
             return payloads.get(method)
 
@@ -138,7 +141,7 @@ async def test_client_methods_build_params_and_decode() -> None:
         parse_mode="Markdown",
         reply_markup={"inline_keyboard": []},
     )
-    assert edit and edit.message_id == 3
+    assert isinstance(edit, Message) and edit.message_id == 3
 
     assert await client.delete_message(1, 2) is True
     assert await client.set_my_commands(
@@ -176,3 +179,46 @@ async def test_decode_result_invalid_payload_returns_none() -> None:
     client = HttpBotClient("token", http_client=httpx.AsyncClient())
     assert client._decode_result(method="getMe", payload=["bad"], model=User) is None
     await client.close()
+
+
+def _mock_client(handler) -> HttpBotClient:
+    return HttpBotClient(
+        "token", http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    )
+
+
+@pytest.mark.anyio
+async def test_edit_message_text_not_modified_is_a_no_op() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "ok": False,
+                "error_code": 400,
+                "description": (
+                    "Bad Request: message is not modified: specified new message "
+                    "content and reply markup are exactly the same"
+                ),
+            },
+        )
+
+    client = _mock_client(handler)
+
+    assert await client.edit_message_text(1, 2, "same") is MESSAGE_UNCHANGED
+
+
+@pytest.mark.anyio
+async def test_edit_message_text_other_400_still_fails() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "ok": False,
+                "error_code": 400,
+                "description": "Bad Request: message to edit not found",
+            },
+        )
+
+    client = _mock_client(handler)
+
+    assert await client.edit_message_text(1, 2, "text") is None

--- a/tests/test_telegram_queue.py
+++ b/tests/test_telegram_queue.py
@@ -432,7 +432,7 @@ async def test_retry_after_retries_once() -> None:
         text="retry",
     )
 
-    assert result is not None
+    assert isinstance(result, Message)
     assert result.message_id == 1
     assert bot._edit_attempts == 2
 


### PR DESCRIPTION
## Summary

An `editMessageText` 400 with `message is not modified` means the message already reads the way we wanted. Today it is logged at ERROR and returns `None` — and a `None` edit makes `_send_or_edit_message` fall through to `send`, so takopi posts a duplicate of the message that was already there.

This reports the case as `MESSAGE_UNCHANGED` instead, and `TelegramTransport.edit` returns the existing ref.

## Notes

The detection is opt-in per call, via a new `benign_400` argument on `_request`/`_post`. Only `edit_message_text` passes it, so no other caller has to know the sentinel exists. `edit_message_text` returns `EditResult = Message | MessageUnchanged | None`; implementations that only ever return `Message | None` still satisfy it, so nothing else needed changing.

Split out of #248, where this rode along unrelated to the rich-messages work.

## Test plan

- [ ] `uv run pytest`
- [ ] `uv run ruff check src/ tests/ && uv run ty check src tests`

Covered by `test_edit_message_text_not_modified_is_a_no_op`, `test_edit_message_text_other_400_still_fails`, and `test_telegram_transport_edit_unchanged_keeps_ref_without_resending`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)