### PR TITLE
fix(telegram): retry the startup getUpdates conflict instead of failing

### DIFF
--- a/src/takopi/telegram/client_api.py
+++ b/src/takopi/telegram/client_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from typing import Any, Protocol, TypeVar
 
 import httpx
@@ -12,6 +13,63 @@ logger = get_logger(__name__)
 
 T = TypeVar("T")
 _NETWORK_RETRY_AFTER_S = 2.0
+
+# ── Startup getUpdates conflict (LOCAL PATCH) ────────────────────────────────
+#
+# Restarting the bridge races Telegram: the previous process's long-poll stays
+# open server-side for the remainder of its timeout (up to 50 s) even after that
+# process has exited and released the config lock. The new instance polls, sees
+# two consumers and gets
+#
+#   409 Conflict: terminated by other getUpdates request; make sure that only
+#   one bot instance is running
+#
+# which is self-limiting — it clears as soon as the old connection drains.
+# Untreated it reached the generic error path: logged at ERROR as
+# telegram.http_error and returned None, which made _drain_backlog give up
+# ("startup.backlog.failed") so pre-restart messages were replayed as new
+# instead of discarded.
+#
+# Inside the startup window it now raises TelegramRetryAfter, which
+# BotClient._call_with_retry_after already retries transparently — no update is
+# lost, because the offset is never advanced past an update that was not
+# received, and Telegram holds undelivered updates for 24 h.
+#
+# The window is deliberately bounded: past it, a persistent 409 means a SECOND
+# bridge really is running on this token, and that must stay a visible error
+# rather than an infinite silent retry.
+_STARTUP_CONFLICT_WINDOW_S = 60.0
+_STARTUP_CONFLICT_BASE_BACKOFF_S = 1.0
+_STARTUP_CONFLICT_MAX_BACKOFF_S = 8.0
+_STARTUP_CONFLICT_MARKER = "terminated by other getupdates"
+
+_process_start = time.monotonic()
+_startup_conflict_attempts = 0
+
+
+def _startup_conflict_backoff(description: str | None) -> float | None:
+    """Backoff for a getUpdates conflict during startup, else None.
+
+    None means "not this case" — the caller must fall through to its normal
+    error handling.
+    """
+    global _startup_conflict_attempts
+    if not description or _STARTUP_CONFLICT_MARKER not in description.lower():
+        return None
+    if time.monotonic() - _process_start > _STARTUP_CONFLICT_WINDOW_S:
+        return None
+    backoff = min(
+        _STARTUP_CONFLICT_BASE_BACKOFF_S * (2**_startup_conflict_attempts),
+        _STARTUP_CONFLICT_MAX_BACKOFF_S,
+    )
+    _startup_conflict_attempts += 1
+    return backoff
+
+
+def _clear_startup_conflicts() -> None:
+    """Reset the backoff ladder once a poll succeeds."""
+    global _startup_conflict_attempts
+    _startup_conflict_attempts = 0
 
 
 class RetryAfter(Exception):
@@ -174,6 +232,24 @@ class HttpBotClient:
                     retry_after=retry_after,
                 )
                 raise TelegramRetryAfter(retry_after)
+            # LOCAL PATCH: expected, self-clearing restart race — retry quietly
+            # instead of reporting it as a failure. See the note at the top.
+            if payload.get("error_code") == 409:
+                description = payload.get("description")
+                backoff = _startup_conflict_backoff(
+                    description if isinstance(description, str) else None
+                )
+                if backoff is not None:
+                    logger.warning(
+                        "telegram.startup_conflict",
+                        method=method,
+                        url=str(resp.request.url),
+                        retry_after=backoff,
+                        description=description,
+                    )
+                    raise TelegramRetryAfter(
+                        backoff, description if isinstance(description, str) else None
+                    )
             logger.error(
                 "telegram.api_error",
                 method=method,
@@ -182,6 +258,7 @@ class HttpBotClient:
             )
             return None
 
+        _clear_startup_conflicts()
         logger.debug("telegram.response", method=method, payload=payload)
         return payload.get("result")
 
@@ -235,6 +312,19 @@ class HttpBotClient:
                 )
                 raise TelegramRetryAfter(retry_after) from exc
             body = resp.text
+            # LOCAL PATCH: Telegram answers the restart race with HTTP 409, so the
+            # conflict arrives here rather than through the ok:false envelope.
+            if resp.status_code == 409:
+                backoff = _startup_conflict_backoff(body)
+                if backoff is not None:
+                    logger.warning(
+                        "telegram.startup_conflict",
+                        method=method,
+                        status=resp.status_code,
+                        url=str(resp.request.url),
+                        retry_after=backoff,
+                    )
+                    raise TelegramRetryAfter(backoff, body) from exc
             logger.error(
                 "telegram.http_error",
                 method=method,

--- a/tests/test_telegram_client_api.py
+++ b/tests/test_telegram_client_api.py
@@ -1,12 +1,15 @@
+import time
+
 import httpx
 import pytest
 
+from takopi.telegram import client_api
+from takopi.telegram.api_models import User
 from takopi.telegram.client_api import (
     HttpBotClient,
     TelegramRetryAfter,
     retry_after_from_payload,
 )
-from takopi.telegram.api_models import User
 
 
 def _response() -> httpx.Response:
@@ -176,3 +179,97 @@ async def test_decode_result_invalid_payload_returns_none() -> None:
     client = HttpBotClient("token", http_client=httpx.AsyncClient())
     assert client._decode_result(method="getMe", payload=["bad"], model=User) is None
     await client.close()
+
+
+def _conflict_description() -> str:
+    return (
+        "Conflict: terminated by other getUpdates request; "
+        "make sure that only one bot instance is running"
+    )
+
+
+@pytest.fixture
+def fresh_startup_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Put the module back into its just-started state."""
+    monkeypatch.setattr(client_api, "_process_start", time.monotonic())
+    monkeypatch.setattr(client_api, "_startup_conflict_attempts", 0)
+
+
+def test_startup_conflict_backoff_is_exponential_and_capped(
+    fresh_startup_window: None,
+) -> None:
+    description = _conflict_description()
+    ladder = [client_api._startup_conflict_backoff(description) for _ in range(6)]
+    assert ladder == [1.0, 2.0, 4.0, 8.0, 8.0, 8.0]
+
+
+def test_startup_conflict_backoff_resets_after_success(
+    fresh_startup_window: None,
+) -> None:
+    description = _conflict_description()
+    client_api._startup_conflict_backoff(description)
+    client_api._startup_conflict_backoff(description)
+    client_api._clear_startup_conflicts()
+    assert client_api._startup_conflict_backoff(description) == 1.0
+
+
+def test_startup_conflict_ignores_other_conflicts(fresh_startup_window: None) -> None:
+    # The webhook variant of 409 is not self-clearing: retrying would hide a real
+    # misconfiguration, so it must fall through to normal error handling.
+    webhook = "Conflict: can't use getUpdates method while webhook is active"
+    assert client_api._startup_conflict_backoff(webhook) is None
+    assert client_api._startup_conflict_backoff(None) is None
+
+
+def test_startup_conflict_expires_after_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Past the window a lingering 409 means a second bridge really is polling
+    # this token, which has to stay visible instead of retrying forever.
+    monkeypatch.setattr(
+        client_api,
+        "_process_start",
+        time.monotonic() - client_api._STARTUP_CONFLICT_WINDOW_S - 1,
+    )
+    monkeypatch.setattr(client_api, "_startup_conflict_attempts", 0)
+    assert client_api._startup_conflict_backoff(_conflict_description()) is None
+
+
+def test_parse_envelope_startup_conflict(fresh_startup_window: None) -> None:
+    client = HttpBotClient("token", http_client=httpx.AsyncClient())
+    payload = {
+        "ok": False,
+        "error_code": 409,
+        "description": _conflict_description(),
+    }
+    with pytest.raises(TelegramRetryAfter) as exc:
+        client._parse_telegram_envelope(
+            method="getUpdates",
+            resp=_response(),
+            payload=payload,
+        )
+    assert exc.value.retry_after == 1.0
+
+
+def test_parse_envelope_conflict_outside_window_is_an_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        client_api,
+        "_process_start",
+        time.monotonic() - client_api._STARTUP_CONFLICT_WINDOW_S - 1,
+    )
+    client = HttpBotClient("token", http_client=httpx.AsyncClient())
+    payload = {
+        "ok": False,
+        "error_code": 409,
+        "description": _conflict_description(),
+    }
+    assert (
+        client._parse_telegram_envelope(
+            method="getUpdates",
+            resp=_response(),
+            payload=payload,
+        )
+        is None
+    )


### PR DESCRIPTION
Fixes #252.

## The race

Restarting the bridge races Telegram. The previous process's long poll stays
open server-side for the remainder of its timeout — up to 50 s — even after that
process has exited and released the config lock. The fresh instance starts
polling, Telegram sees two consumers of the same token and answers:

```
409 Conflict: terminated by other getUpdates request; make sure that only one
bot instance is running
```

It is self-clearing: it stops as soon as the old connection drains. The config
lock cannot prevent it — `lockfile._pid_running` only blocks a second instance
while the previous pid is alive, and the race happens after the old process is
gone but its connection is not.

Until now the conflict reached the generic error path, so it was logged at ERROR
as `telegram.http_error` and `get_updates` returned `None`. `_drain_backlog`
gives up on `None` (`startup.backlog.failed`), so the pre-restart backlog was
never discarded and got replayed as new messages on the next poll.

## The change

Within a 60 s window after start, that specific 409 raises
`TelegramRetryAfter`, which `BotClient._call_with_retry_after` already retries
transparently — no new machinery. Backoff is exponential, 1→2→4→8 s, capped, and
the ladder resets on the first successful call. Nothing is lost while it
retries: the offset is never advanced past an update that was not received, and
Telegram holds undelivered updates for 24 h.

Both 409 paths are covered, since Telegram signals this with an HTTP 409 status
as well as through the `ok:false` envelope.

Two deliberate limits:

- **Only** `terminated by other getUpdates` is treated this way. The other 409,
  `can't use getUpdates method while webhook is active`, is not self-clearing —
  retrying it would bury a real misconfiguration.
- **Past the window** a lingering conflict means a second bridge genuinely is
  polling this token, and that stays a visible error rather than an infinite
  silent retry.

The log line for the handled case is a WARNING, `telegram.startup_conflict`,
carrying the chosen backoff.

## Tests

Six tests added to `tests/test_telegram_client_api.py`, in the style of the
existing `test_parse_envelope_rate_limited`:

| test | asserts |
| --- | --- |
| `backoff_is_exponential_and_capped` | ladder is `[1, 2, 4, 8, 8, 8]` |
| `backoff_resets_after_success` | back to `1.0` after `_clear_startup_conflicts()` |
| `ignores_other_conflicts` | webhook-variant 409 and `None` description → not retried |
| `expires_after_window` | past the window → not retried |
| `parse_envelope_startup_conflict` | envelope path raises `TelegramRetryAfter(1.0)` |
| `parse_envelope_conflict_outside_window_is_an_error` | past the window → returns `None` |

`pytest tests/test_telegram_client_api.py` → **13 passed**.

Full suite locally: **27 failed, 572 passed**, against a **27 failed, 566
passed** baseline on unmodified `master` — same pre-existing failures (they look
Windows-specific, around subprocess handling), plus the 6 new tests. `ruff check`
and `ruff format --check` are clean on both touched files.
