### PR TITLE
fix(lockfile): hold the single-instance lock in the OS, not in a pid file

### DIFF
--- a/src/takopi/lockfile.py
+++ b/src/takopi/lockfile.py
@@ -3,12 +3,50 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import sys
+import contextlib
 from dataclasses import dataclass
 from pathlib import Path
+from typing import IO
 
 from .logging import get_logger
 
 logger = get_logger(__name__)
+
+# The advisory lock is taken on a byte far past anything we write. On Windows a
+# locked range is mandatory, so a lock covering the JSON would stop a second
+# instance from reading the file to report who is holding it.
+_LOCK_OFFSET = 1 << 30
+
+if sys.platform == "win32":  # pragma: no cover - platform specific
+    import msvcrt
+
+    def _try_acquire_os_lock(fh: IO[str]) -> bool:
+        try:
+            fh.seek(_LOCK_OFFSET)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
+        except OSError:
+            return False
+        return True
+
+    def _release_os_lock(fh: IO[str]) -> None:
+        with contextlib.suppress(OSError):
+            fh.seek(_LOCK_OFFSET)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+
+else:  # pragma: no cover - platform specific
+    import fcntl
+
+    def _try_acquire_os_lock(fh: IO[str]) -> bool:
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return False
+        return True
+
+    def _release_os_lock(fh: IO[str]) -> None:
+        with contextlib.suppress(OSError):
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,17 +61,25 @@ class LockError(RuntimeError):
         *,
         path: Path,
         state: str,
+        holder_pid: int | None = None,
     ) -> None:
         self.path = path
         self.state = state
-        super().__init__(_format_lock_message(path, state))
+        self.holder_pid = holder_pid
+        super().__init__(_format_lock_message(path, state, holder_pid))
 
 
 @dataclass(slots=True)
 class LockHandle:
     path: Path
+    file: IO[str] | None = None
 
     def release(self) -> None:
+        fh, self.file = self.file, None
+        if fh is not None:
+            _release_os_lock(fh)
+            with contextlib.suppress(OSError):
+                fh.close()
         try:
             self.path.unlink(missing_ok=True)
         except OSError as exc:
@@ -63,34 +109,47 @@ def lock_path_for_config(config_path: Path) -> Path:
 def acquire_lock(
     *, config_path: Path, token_fingerprint: str | None = None
 ) -> LockHandle:
+    """Take the single-instance lock, or raise LockError if someone holds it.
+
+    Exclusivity comes from an advisory lock the OS holds on an open file
+    descriptor, not from the pid recorded in the file. The kernel drops it the
+    moment the owning process exits — however it exits — so the lock cannot go
+    stale, cannot be defeated by pid reuse, and does not depend on one process
+    being allowed to inspect another. The pid and token fingerprint are still
+    written, purely so a second instance can name the holder.
+    """
     cfg_path = config_path.expanduser().resolve()
     lock_path = lock_path_for_config(cfg_path)
     try:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
-        existing = _read_lock_info(lock_path)
-        if existing:
-            if (
-                token_fingerprint
-                and existing.token_fingerprint
-                and existing.token_fingerprint != token_fingerprint
-            ):
-                _write_lock_info(
-                    lock_path,
-                    pid=os.getpid(),
-                    token_fingerprint=token_fingerprint,
-                )
-                return LockHandle(path=lock_path)
-            if _pid_running(existing.pid):
-                raise LockError(path=lock_path, state="running") from None
-        _write_lock_info(
-            lock_path,
-            pid=os.getpid(),
-            token_fingerprint=token_fingerprint,
-        )
+        lock_path.touch(exist_ok=True)
+        # "r+", not "a+": on Windows an append handle ignores seek() on write,
+        # so a stale payload from a previous owner could never be overwritten.
+        fh = open(lock_path, "r+", encoding="utf-8")  # noqa: SIM115
     except OSError as exc:
         raise LockError(path=lock_path, state=str(exc)) from exc
 
-    return LockHandle(path=lock_path)
+    if not _try_acquire_os_lock(fh):
+        # Read the holder for the message only. The lock deliberately sits past
+        # the payload so this read still works.
+        holder = _read_lock_info(lock_path)
+        with contextlib.suppress(OSError):
+            fh.close()
+        raise LockError(
+            path=lock_path,
+            state="running",
+            holder_pid=holder.pid if holder else None,
+        )
+
+    try:
+        _write_lock_info(fh, pid=os.getpid(), token_fingerprint=token_fingerprint)
+    except OSError as exc:
+        _release_os_lock(fh)
+        with contextlib.suppress(OSError):
+            fh.close()
+        raise LockError(path=lock_path, state=str(exc)) from exc
+
+    return LockHandle(path=lock_path, file=fh)
 
 
 def _read_lock_info(path: Path) -> LockInfo | None:
@@ -118,14 +177,20 @@ def _read_lock_info(path: Path) -> LockInfo | None:
     )
 
 
-def _write_lock_info(path: Path, *, pid: int, token_fingerprint: str | None) -> None:
+def _write_lock_info(fh: IO[str], *, pid: int, token_fingerprint: str | None) -> None:
     payload = {"pid": pid, "token_fingerprint": token_fingerprint}
-    path.write_text(
-        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    fh.seek(0)
+    fh.truncate(0)
+    fh.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    fh.flush()
 
 
 def _pid_running(pid: int | None) -> bool:
+    """Best-effort liveness check, used for diagnostics only.
+
+    Exclusivity no longer rests on this: on Windows a non-elevated process
+    cannot open an elevated one, and a recycled pid looks alive when it is not.
+    """
     if pid is None or pid <= 0:
         return False
     try:
@@ -139,13 +204,20 @@ def _pid_running(pid: int | None) -> bool:
     return True
 
 
-def _format_lock_message(path: Path, state: str) -> str:
+def _format_lock_message(path: Path, state: str, holder_pid: int | None = None) -> str:
     if state != "running":
         return f"error: lock failed: {state}"
-    header = "error: already running"
+    who = f" (pid {holder_pid})" if holder_pid else ""
     display_path = _display_lock_path(path)
-    lines = [header, f"remove {display_path} if stale"]
-    return "\n".join(lines)
+    return "\n".join(
+        [
+            f"error: takopi is already running{who}",
+            "stop that instance before starting another one — two bridges on the "
+            "same token fight over getUpdates and every message is handled twice",
+            f"the lock is held by the OS and released when that process exits, so "
+            f"deleting {display_path} will not help",
+        ]
+    )
 
 
 def _display_lock_path(path: Path) -> str:

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -38,7 +38,11 @@ def test_lockfile_refuses_running_pid(tmp_path) -> None:
             )
         message = str(exc.value).lower()
         assert "already running" in message
-        assert str(lockfile.lock_path_for_config(config_path)) in str(exc.value)
+        # The message shortens paths under $HOME to ~/…, and pytest's tmp_path
+        # lives under $HOME on Windows — so compare against the displayed form
+        # rather than the absolute one.
+        lock_path = lockfile.lock_path_for_config(config_path)
+        assert lockfile._display_lock_path(lock_path) in str(exc.value)
     finally:
         handle.release()
 
@@ -64,7 +68,7 @@ def test_lockfile_replaces_dead_pid(tmp_path, monkeypatch) -> None:
         handle.release()
 
 
-def test_lockfile_replaces_token_mismatch(tmp_path) -> None:
+def test_lockfile_rewrites_token_of_a_stale_lock(tmp_path) -> None:
     config_path = tmp_path / "takopi.toml"
     config_path.write_text("ok", encoding="utf-8")
     lock_path = lockfile.lock_path_for_config(config_path)
@@ -78,5 +82,108 @@ def test_lockfile_replaces_token_mismatch(tmp_path) -> None:
     try:
         updated = json.loads(lock_path.read_text(encoding="utf-8"))
         assert updated["token_fingerprint"] == "deadbeef"
+    finally:
+        handle.release()
+
+
+def test_lockfile_refuses_second_instance_even_with_a_foreign_live_pid(
+    tmp_path, monkeypatch
+) -> None:
+    """A live holder must win regardless of what the file claims.
+
+    The pid in the file is only a hint. Pretending every recorded pid is dead —
+    which is what a non-elevated process saw when an elevated one held the
+    lock, and what a recycled pid produces — must not let a second instance in.
+    """
+    config_path = tmp_path / "takopi.toml"
+    config_path.write_text("ok", encoding="utf-8")
+
+    handle = lockfile.acquire_lock(
+        config_path=config_path,
+        token_fingerprint="deadbeef",
+    )
+    try:
+        monkeypatch.setattr(lockfile, "_pid_running", lambda pid: False)
+        with pytest.raises(lockfile.LockError):
+            lockfile.acquire_lock(
+                config_path=config_path,
+                token_fingerprint="deadbeef",
+            )
+    finally:
+        handle.release()
+
+
+def test_lockfile_refuses_second_instance_on_token_mismatch(tmp_path) -> None:
+    """A different token must not hand the lock to a second live instance.
+
+    Taking the lock over on a fingerprint mismatch used to bypass the liveness
+    check entirely, which is a second way to end up with two bridges running.
+    """
+    config_path = tmp_path / "takopi.toml"
+    config_path.write_text("ok", encoding="utf-8")
+
+    handle = lockfile.acquire_lock(config_path=config_path, token_fingerprint="aaa")
+    try:
+        with pytest.raises(lockfile.LockError):
+            lockfile.acquire_lock(config_path=config_path, token_fingerprint="bbb")
+    finally:
+        handle.release()
+
+
+def test_lockfile_message_names_the_holder(tmp_path) -> None:
+    config_path = tmp_path / "takopi.toml"
+    config_path.write_text("ok", encoding="utf-8")
+
+    handle = lockfile.acquire_lock(
+        config_path=config_path,
+        token_fingerprint="deadbeef",
+    )
+    try:
+        with pytest.raises(lockfile.LockError) as exc:
+            lockfile.acquire_lock(
+                config_path=config_path,
+                token_fingerprint="deadbeef",
+            )
+        message = str(exc.value)
+        assert "already running" in message
+        assert f"pid {os.getpid()}" in message
+        assert exc.value.holder_pid == os.getpid()
+    finally:
+        handle.release()
+
+
+def test_lockfile_frees_the_os_lock_on_release(tmp_path) -> None:
+    config_path = tmp_path / "takopi.toml"
+    config_path.write_text("ok", encoding="utf-8")
+
+    first = lockfile.acquire_lock(config_path=config_path, token_fingerprint="x")
+    first.release()
+
+    second = lockfile.acquire_lock(config_path=config_path, token_fingerprint="x")
+    try:
+        payload = json.loads(
+            lockfile.lock_path_for_config(config_path).read_text(encoding="utf-8")
+        )
+        assert payload["pid"] == os.getpid()
+    finally:
+        second.release()
+
+
+def test_lockfile_ignores_a_stale_file_without_an_os_lock(tmp_path) -> None:
+    """A leftover file from a crashed run must not block a fresh start."""
+    config_path = tmp_path / "takopi.toml"
+    config_path.write_text("ok", encoding="utf-8")
+    lock_path = lockfile.lock_path_for_config(config_path)
+    lock_path.write_text(
+        json.dumps({"pid": os.getpid(), "token_fingerprint": "deadbeef"}),
+        encoding="utf-8",
+    )
+
+    handle = lockfile.acquire_lock(
+        config_path=config_path,
+        token_fingerprint="deadbeef",
+    )
+    try:
+        assert lock_path.exists()
     finally:
         handle.release()


### PR DESCRIPTION
Fixes #254. Related to #252 / #253 — same restart territory, independent change,
so they are kept apart and can land in either order.

## The bug

Two bridges ran against the same token for hours on one machine: one pair
started at 11:26, a second at 22:28 while the first was still alive. Both polled
`getUpdates`, so every message was handled twice and the agent launches
collided.

The guard failed because exclusivity rested on a pid written into the lock file.
That pid is only a hint about a process, and it goes stale invisibly. On the
affected machine the lock recorded pid 5140, already exited while the bridge was
still running, so the next start read a dead pid and walked in. Three further
holes in the same design:

- a fingerprint mismatch takes the lock over without consulting the pid at all
  (`lockfile.py:72-82`);
- read-then-write is not atomic, so two simultaneous starts can both see a free
  lock and both write;
- a recycled pid makes a stale lock look alive forever — the opposite failure, a
  bridge that will not start until the file is deleted by hand.

## The change

Exclusivity now comes from an advisory lock the OS holds on an open descriptor —
`msvcrt.locking` on Windows, `fcntl.flock` elsewhere — kept for the process
lifetime. The kernel releases it however the process dies, so the lock cannot go
stale, survives pid reuse, and never depends on one process being allowed to
inspect another. The pid and fingerprint are still written, now purely so the
loser can name the holder.

The lock is taken on a byte far past the payload. On Windows a locked range is
mandatory, and a lock covering the JSON would stop the second instance from
reading the file to report who holds it.

The refusal message names the holding pid, says what actually goes wrong when
two bridges share a token, and states that deleting the lock file will not help
— the old `remove … if stale` line is actively misleading once the OS owns the
lock.

`_pid_running` is kept for diagnostics, with a note that it is not usable as a
guard on Windows.

### Behaviour change worth a look

Previously a token-fingerprint mismatch let a second instance take the lock from
a **live** holder. That is now refused. Nothing is lost: once the old process is
gone the OS lock is free, so changing the token and restarting still works.

## Verifying it was not something else

Two plausible suspects that turned out innocent, checked against a sacrificial
process on CPython 3.14 / Windows 11, in case they save someone else the detour:

- A non-elevated process reading an elevated one's pid does **not** misreport it:
  `os.kill(pid, 0)` raises `PermissionError` (winerror 5), and `_pid_running`
  maps that to `True` correctly.
- `os.kill(pid, 0)` does **not** terminate the target on this platform.

## Tests

Five added to `tests/test_lockfile.py`:

| test | asserts |
| --- | --- |
| `refuses_second_instance_even_with_a_foreign_live_pid` | a live holder wins even when `_pid_running` is stubbed to always say "dead" |
| `refuses_second_instance_on_token_mismatch` | the fingerprint bypass no longer admits a second live instance |
| `message_names_the_holder` | the message carries the holding pid, and `LockError.holder_pid` is set |
| `frees_the_os_lock_on_release` | release makes the lock available again |
| `ignores_a_stale_file_without_an_os_lock` | a leftover file from a crashed run does not block a fresh start |

`pytest tests/test_lockfile.py` → **9 passed**.

Also fixes a pre-existing Windows failure in `test_lockfile_refuses_running_pid`:
it asserted the absolute path appears in the message, but the message shortens
paths under `$HOME` to `~/…`, and pytest's `tmp_path` lives under `$HOME` on
Windows. It fails on unmodified `master` there.

Full suite locally: **26 failed, 571 passed**, against **27 failed, 566 passed**
on unmodified `master` — the same pre-existing failures minus that one, plus the
5 new tests. `ruff check` and `ruff format --check` clean on both files.
